### PR TITLE
fix(StudyClient): use setTimeout to avoid setState warning in useEffect

### DIFF
--- a/src/app/study/StudyClient.tsx
+++ b/src/app/study/StudyClient.tsx
@@ -23,7 +23,11 @@ export default function StudyClient({ words }: Props) {
 
   // Initial load
   useEffect(() => {
-    pickRandomWord();
+    // Use setTimeout to avoid "setState in effect" warning and ensure client-side execution
+    const timer = setTimeout(() => {
+      pickRandomWord();
+    }, 0);
+    return () => clearTimeout(timer);
   }, [pickRandomWord]);
 
   const handleRemembered = () => {


### PR DESCRIPTION
The warning occurs when setting state immediately in useEffect during initial render. Wrapping in setTimeout ensures the state update happens after the component is mounted.