### PR TITLE
Add PNG favicon option to site metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,51 +15,54 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-	metadataBase: new URL("https://toeic-words.com"),
-	title: {
-		default: "TOEIC重要単語",
-		template: "%s | TOEIC重要単語",
-	},
-	description: "TOEIC頻出の重要単語をAI解説で効率よく学べる",
-	keywords: ["TOEIC", "英単語", "単語帳", "学習", "例文"],
-	icons: {
-		icon: [{ url: "/favicon.ico", type: "image/x-icon" }],
-		shortcut: "/favicon.ico",
-		apple: [{ url: "/apple-icon.png", type: "image/png" }],
-	},
-	robots: {
-		index: true,
-		follow: true,
-		googleBot: {
-			index: true,
-			follow: true,
-			"max-image-preview": "large",
-			"max-snippet": -1,
-			"max-video-preview": -1,
-		},
-	},
-	openGraph: {
-		title: "TOEIC重要単語",
-		description: "TOEIC頻出の重要単語をAI解説で効率よく学べる",
-		url: "https://toeic-words.com",
-		siteName: "TOEIC重要単語",
-		locale: "ja_JP",
-		type: "website",
-		images: [
-			{
-				url: "/opengraph-image",
-				width: 1200,
-				height: 630,
-				alt: "TOEIC重要単語",
-			},
-		],
-	},
-	twitter: {
-		card: "summary_large_image",
-		title: "TOEIC重要単語",
-		description: "TOEIC頻出の重要単語をAI解説で効率よく学べる",
-		images: ["/opengraph-image"],
-	},
+  metadataBase: new URL("https://toeic-words.com"),
+  title: {
+    default: "TOEIC重要単語",
+    template: "%s | TOEIC重要単語",
+  },
+  description: "TOEIC頻出の重要単語をAI解説で効率よく学べる",
+  keywords: ["TOEIC", "英単語", "単語帳", "学習", "例文"],
+  icons: {
+    icon: [
+      { url: "/favicon.ico", type: "image/x-icon" },
+      { url: "/icon.png", type: "image/png" },
+    ],
+    shortcut: "/favicon.ico",
+    apple: [{ url: "/apple-icon.png", type: "image/png" }],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
+  },
+  openGraph: {
+    title: "TOEIC重要単語",
+    description: "TOEIC頻出の重要単語をAI解説で効率よく学べる",
+    url: "https://toeic-words.com",
+    siteName: "TOEIC重要単語",
+    locale: "ja_JP",
+    type: "website",
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: "TOEIC重要単語",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "TOEIC重要単語",
+    description: "TOEIC頻出の重要単語をAI解説で効率よく学べる",
+    images: ["/opengraph-image"],
+  },
 };
 
 export const viewport: Viewport = {


### PR DESCRIPTION
## Summary
- add PNG favicon entry alongside the existing ICO to improve favicon discovery
- tidy metadata formatting in the root layout for readability

## Testing
- npm run lint (warning: existing unused variable in src/app/words/[word]/page.tsx)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69528b1513fc8320afe0f6507430b1c4)