### PR TITLE
Add decline option to cookie consent dialog

### DIFF
--- a/src/components/common/CookieConsent.tsx
+++ b/src/components/common/CookieConsent.tsx
@@ -26,6 +26,11 @@ export function CookieConsent() {
     window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
   }, []);
 
+  const handleDecline = useCallback(() => {
+    localStorage.setItem(STORAGE_KEY, "declined");
+    window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
+  }, []);
+
   if (accepted) return null;
 
   return (
@@ -41,12 +46,20 @@ export function CookieConsent() {
           </Link>
           をご確認ください。
         </p>
-        <button
-          onClick={handleAccept}
-          className="shrink-0 rounded-lg bg-blue-600 px-6 py-2 text-xs font-medium text-white transition-colors hover:bg-blue-700"
-        >
-          同意する
-        </button>
+        <div className="flex shrink-0 gap-2">
+          <button
+            onClick={handleDecline}
+            className="rounded-lg border border-black/20 px-6 py-2 text-xs font-medium text-black/70 transition-colors hover:bg-black/5 dark:border-white/20 dark:text-white/70 dark:hover:bg-white/5"
+          >
+            同意しない
+          </button>
+          <button
+            onClick={handleAccept}
+            className="rounded-lg bg-blue-600 px-6 py-2 text-xs font-medium text-white transition-colors hover:bg-blue-700"
+          >
+            同意する
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Enhanced the cookie consent component by adding a "decline" button alongside the existing "accept" button, giving users explicit control over cookie preferences.

## Key Changes
- Added `handleDecline` callback function that sets the storage key to "declined" and dispatches a storage event
- Restructured the button layout from a single accept button to a two-button layout using flexbox
- Implemented a secondary "decline" button (同意しない) with a subtle border style that supports dark mode
- Maintained the primary "accept" button (同意する) with its original blue styling

## Implementation Details
- The decline button uses a neutral border-based design with hover effects that work in both light and dark modes
- Both buttons are wrapped in a flex container with gap spacing for proper alignment
- The decline functionality mirrors the accept flow by persisting the user's choice to localStorage and triggering a storage event for synchronization across tabs

https://claude.ai/code/session_0154LLCMNHuokadUSABLWEFY