### PR TITLE
fix: Suspenseフォールバックに前単語/次単語のnavプレースホルダーを追加

### DIFF
--- a/src/app/words/[word]/layout.tsx
+++ b/src/app/words/[word]/layout.tsx
@@ -19,22 +19,32 @@ export default async function WordLayout({
         <main className="w-full max-w-[960px] flex flex-col gap-6">
           <Suspense
             fallback={
-              <header className="flex flex-col gap-4">
-                <div className="flex items-center gap-3 whitespace-nowrap overflow-x-auto pb-1 -mb-1">
-                  <Link 
-                    href="/" 
-                    className="group inline-flex items-center justify-center gap-1.5 h-10 px-4 bg-white border border-gray-200 rounded-full text-slate-600 text-[15px] font-semibold no-underline transition-all duration-200 shadow-sm select-none hover:bg-gray-50 hover:border-gray-300 hover:text-slate-900 hover:-translate-y-px hover:shadow-md active:translate-y-0 active:shadow-sm"
-                  >
-                    <ChevronLeft size={18} className="transition-transform group-hover:-translate-x-0.5 text-slate-400 group-hover:text-slate-600" />
-                    単語一覧
-                  </Link>
-                  <span className="text-slate-300 text-lg">/</span>
-                  <span className="text-slate-700 text-lg font-bold tracking-wide uppercase">...</span>
-                </div>
-                <div className="flex justify-between gap-4 items-end">
-                  <h2 className="text-xl leading-[1.4] text-slate-900 tracking-[0.02em]">AI単語解説</h2>
-                </div>
-              </header>
+              <>
+                <header className="flex flex-col gap-4">
+                  <div className="flex items-center gap-3 whitespace-nowrap overflow-x-auto pb-1 -mb-1">
+                    <Link
+                      href="/"
+                      className="group inline-flex items-center justify-center gap-1.5 h-10 px-4 bg-white border border-gray-200 rounded-full text-slate-600 text-[15px] font-semibold no-underline transition-all duration-200 shadow-sm select-none hover:bg-gray-50 hover:border-gray-300 hover:text-slate-900 hover:-translate-y-px hover:shadow-md active:translate-y-0 active:shadow-sm"
+                    >
+                      <ChevronLeft size={18} className="transition-transform group-hover:-translate-x-0.5 text-slate-400 group-hover:text-slate-600" />
+                      単語一覧
+                    </Link>
+                    <span className="text-slate-300 text-lg">/</span>
+                    <span className="text-slate-700 text-lg font-bold tracking-wide uppercase">...</span>
+                  </div>
+                  <div className="flex justify-between gap-4 items-end">
+                    <h2 className="text-xl leading-[1.4] text-slate-900 tracking-[0.02em]">AI単語解説</h2>
+                  </div>
+                </header>
+                <nav className="flex justify-between items-center -mt-2 pb-0 -mb-2" aria-label="単語ナビゲーション">
+                  <span className="inline-flex items-center justify-center gap-1.5 h-9 px-4 bg-white border border-gray-200 rounded-full text-gray-600 text-[13px] font-medium no-underline transition-all duration-200 shadow-sm select-none invisible pointer-events-none">
+                    <span aria-hidden="true">←</span> 前単語
+                  </span>
+                  <span className="inline-flex items-center justify-center gap-1.5 h-9 px-4 bg-white border border-gray-200 rounded-full text-gray-600 text-[13px] font-medium no-underline transition-all duration-200 shadow-sm select-none invisible pointer-events-none">
+                    次単語 <span aria-hidden="true">→</span>
+                  </span>
+                </nav>
+              </>
             }
           >
             <WordNavigation currentSlug={word} />


### PR DESCRIPTION
WordNavigationClientがuseSearchParams()を使うため、静的生成ページでは
ハイドレーション前にSuspenseフォールバックが表示される。従来のフォールバックは
<header>のみでnavが存在せず、初回アクセス時にボタンが見えなかった。
invisibleプレースホルダーを追加することでレイアウトスペースを確保し、
ハイドレーション後の実コンポーネントとのCLSをゼロにする。

https://claude.ai/code/session_0113jgJUw6byUUwQHxaSyh3i