### PR TITLE
fix(tts): use full cache chain in allowlist check to prevent false rejections

### DIFF
--- a/src/app/api/tts/route.ts
+++ b/src/app/api/tts/route.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { Ratelimit } from "@upstash/ratelimit";
 import { getRedis } from "@/lib/upstash";
 import { getWordBySlug } from "@/data/words";
-import { getWordDetails as getCachedWordDetails } from "@/lib/wordCache";
+import { getWordDetail } from "@/data/word-detail";
 import { createHash } from "crypto";
 
 function normalizeText(s: string): string {
@@ -17,7 +17,10 @@ async function isAllowedExampleText(
   const entry = await getWordBySlug(wordSlug.trim().toLowerCase());
   if (!entry) return false;
 
-  const detail = await getCachedWordDetails(entry.term);
+  // Use the full cache chain (L1 → L2 → Gemini) so that an expired Redis entry
+  // does not incorrectly reject valid example text that is still in the Next.js
+  // Data Cache (L1).
+  const detail = await getWordDetail(entry.slug);
   if (!detail) return false;
 
   const target = normalizeText(text);


### PR DESCRIPTION
isAllowedExampleText was calling getCachedWordDetails (Redis-only L2) to
validate example text. When the Redis TTL expired while the Next.js Data
Cache (L1, weeks-long TTL) still held valid word detail, every example-text
TTS request was rejected with 400, showing "音声の再生に失敗しました" to
the user.

Replace the Redis-only lookup with getWordDetail (L1 → L2 → Gemini), which
mirrors the full cache chain used by the listen player itself. The two code
paths now read from the same L1 cache, so an expired Redis entry no longer
causes spurious allowlist failures.

https://claude.ai/code/session_01Bnv6xs9EsTHVnTUZb2tcCy