### PR TITLE
セキュリティ/CI ハードニング（型チェック・トークン比較・Origin 検証・SDK 表記）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,7 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-
       - run: npm ci
       - run: npm run lint --if-present
+      # 型エラー・本番ビルド破壊を CI で検知する（Gemini API Key 無しでも型チェックは通る）
+      - run: npm run typecheck --if-present
       - run: npm run test --if-present
       #- run: npm run build

--- a/.trae/documents/技術ドキュメント.md
+++ b/.trae/documents/技術ドキュメント.md
@@ -1,6 +1,6 @@
 # TOEIC重要単語（toeic_website_ver2.0）技術ドキュメント
 
-最終更新日: 2026-06-04
+最終更新日: 2026-06-08
 
 ## 1. プロジェクト概要
 
@@ -31,7 +31,7 @@
 
 | 区分    | 技術                                    | 用途                  |
 | ----- | ------------------------------------- | ------------------- |
-| 生成AI  | Google Gemini（@google/generative-ai）  | 単語詳細JSONの生成 (gemini-2.5-flash-lite) |
+| 生成AI  | Google Gemini（@google/genai の GoogleGenAI）  | 単語詳細JSONの生成 (gemini-2.5-flash-lite) |
 | キャッシュ | Upstash Redis（@upstash/redis）         | 生成結果の永続キャッシュ（TTLあり） |
 | 音声合成  | Google Cloud Text-to-Speech（HTTP API） | 発音音声（MP3）生成         |
 
@@ -196,7 +196,7 @@
 
   * 静的生成/サーバ実行を用途に応じて使い分け可能
 
-* Google Gemini（@google/generative-ai）
+* Google Gemini（@google/genai の GoogleGenAI）
 
   * モデル: `gemini-2.5-flash-lite` を採用し、高速かつ安価に生成
   * TOEIC向けの「所定JSONスキーマ」で語義・例文等を生成する用途に適合
@@ -214,7 +214,7 @@
 
 * `next`, `react`, `react-dom`: アプリ本体
 * `tailwindcss`, `postcss`, `autoprefixer`: CSSフレームワークとビルドツール
-* `@google/generative-ai`: サーバ側データ取得（`src/data/word-detail.ts`）でGeminiを呼び出す
+* `@google/genai`（`GoogleGenAI`）: サーバ側データ取得（`src/data/word-detail.ts`）でGeminiを呼び出す
 * `@upstash/redis`: サーバ側キャッシュ（`src/lib/upstash.ts`, `src/lib/wordCache.ts`）
 * `@vercel/blob`: Vercel Blob から単語リストファイル（`words-file/word.txt`, `word_mid.txt`, `word_high.txt`）を取得する
 * `@vercel/analytics`, `@vercel/speed-insights`: アクセス解析・パフォーマンス計測
@@ -839,3 +839,4 @@ export type WordDetails = {
 | 2026-05-31 | 3.4 | -   | 「お気に入り単語 聞き流しモード」（`/favorites/listen`）を追加。 |
 | 2026-06-04 | 3.5 | -   | 自動テスト（Vitest ユニットテスト）を整備し CI に組み込み。`server-only` 付きモジュール内の純粋ロジックを `src/lib/` 配下に切り出して単体テスト可能化：(1) `word-select.ts`（`words.ts` から単語パース／重複排除・FNV-1a ハッシュ・JST 日付キー・「今日の5単語」選定を抽出）、(2) `word-detail-parse.ts`（`word-detail.ts` から Gemini 応答の JSON 抽出・正規化を抽出）、(3) `tts-utils.ts`（`api/tts/route.ts` からテキスト正規化・slug サニタイズ・キャッシュキー生成・例文 allowlist マッチングを抽出）、(4) `listen-utils.ts`（`useListenPlayer.ts` から `pickExample` を抽出、フックは後方互換で re-export）。各 `src/lib/(tests)/*.test.ts` に計39テストを追加（外部シークレット不要）。`.github/workflows/ci.yml` に `npm run test` ステップを追加し、lint と併せてマージ条件とした。 |
 | 2026-06-07 | 3.6 | -   | 寄付募集ページ（`/donate`）を追加。Amazon ギフト券（E メールタイプ）による任意の寄付を募集し、寄付方法・使い道・留意事項を掲載。Footer に「寄付のお願い」導線を追加。 |
+| 2026-06-08 | 3.7 | -   | セキュリティ／CI ハードニング：(1) CI（`.github/workflows/ci.yml`）に `npm run typecheck`（`tsc --noEmit`）ステップを追加し、型エラー・本番ビルド破壊が lint/test をすり抜けないようにした（`package.json` に `typecheck` スクリプト追加）。(2) 各 `/api/revalidate/*` のトークン比較を `src/lib/safe-compare.ts:safeEqual`（SHA-256 ハッシュ後に `crypto.timingSafeEqual`）に置換し、タイミング攻撃と長さリークを排除。(3) `/api/tts` の Origin/Referer 検証を部分一致（`includes`）から `src/lib/tts-utils.ts:isSameHost`（`new URL().host` の厳密一致）に変更し、`example.com.attacker.com` 型のバイパスを防止。(4) README／本ドキュメントの AI SDK 表記を実態（`@google/genai` の `GoogleGenAI`）に修正。 |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A comprehensive web application for learning essential TOEIC vocabulary, featuri
 - **UI**: React 19, [Tailwind CSS v3.4](https://tailwindcss.com/) (Utility-first CSS), Lucide React
 - **Compiler**: React Compiler (`babel-plugin-react-compiler`) for automatic memoization
 - **Social**: react-share
-- **AI**: Google Gemini (`@google/generative-ai`) - model: `gemini-2.5-flash-lite`
+- **AI**: Google Gemini (`@google/genai` / `GoogleGenAI`) - model: `gemini-2.5-flash-lite`
 - **Database / Cache**: Upstash Redis (`@upstash/redis`)
 - **Storage**: Vercel Blob (`@vercel/blob`) - for word lists
 - **Analytics**: Google Analytics 4 (via `@next/third-parties`), Vercel Analytics & Speed Insights

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
   "dependencies": {

--- a/src/app/api/revalidate/today-words/route.ts
+++ b/src/app/api/revalidate/today-words/route.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { revalidateTag } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
+import { safeEqual } from '@/lib/safe-compare';
 
 // Vercel Cron からは Authorization: Bearer <CRON_SECRET> ヘッダ、
 // 手動実行時は ?token=<REVALIDATION_TOKEN> クエリの両方を受け付ける
@@ -10,8 +11,11 @@ export async function GET(request: NextRequest) {
   const secret = process.env.REVALIDATION_TOKEN;
   const cronSecret = process.env.CRON_SECRET;
 
-  const validQueryToken = !!secret && token === secret;
-  const validCronAuth = !!cronSecret && authHeader === `Bearer ${cronSecret}`;
+  const bearer = authHeader?.startsWith('Bearer ')
+    ? authHeader.slice('Bearer '.length)
+    : null;
+  const validQueryToken = safeEqual(token, secret);
+  const validCronAuth = safeEqual(bearer, cronSecret);
 
   if (!validQueryToken && !validCronAuth) {
     return NextResponse.json({ message: 'Invalid token' }, { status: 401 });

--- a/src/app/api/revalidate/upstash-word/route.ts
+++ b/src/app/api/revalidate/upstash-word/route.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { NextRequest, NextResponse } from "next/server";
 import { cacheKeyForWord, deleteWordDetails } from "@/lib/wordCache";
+import { safeEqual } from "@/lib/safe-compare";
 
 const NO_STORE_HEADERS = { "Cache-Control": "no-store" } as const;
 
@@ -12,7 +13,7 @@ export async function GET(request: NextRequest) {
   const key = request.nextUrl.searchParams.get("key");
   const secret = process.env.REVALIDATION_TOKEN;
 
-  if (!secret || !token || token !== secret) {
+  if (!safeEqual(token, secret)) {
     return NextResponse.json(
       { message: "Invalid token" },
       { status: 401, headers: NO_STORE_HEADERS },

--- a/src/app/api/revalidate/word/route.ts
+++ b/src/app/api/revalidate/word/route.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { revalidateTag } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 import { deleteWordDetails } from '@/lib/wordCache';
+import { safeEqual } from '@/lib/safe-compare';
 
 export async function GET(request: NextRequest) {
   const token = request.nextUrl.searchParams.get('token');
@@ -9,7 +10,7 @@ export async function GET(request: NextRequest) {
   const clearUpstash = request.nextUrl.searchParams.get('upstash') === 'true';
   const secret = process.env.REVALIDATION_TOKEN;
 
-  if (!secret || token !== secret) {
+  if (!safeEqual(token, secret)) {
     return NextResponse.json({ message: 'Invalid token' }, { status: 401 });
   }
 

--- a/src/app/api/revalidate/words/route.ts
+++ b/src/app/api/revalidate/words/route.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { revalidateTag } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
+import { safeEqual } from '@/lib/safe-compare';
 
 export async function GET(request: NextRequest) {
   const token = request.nextUrl.searchParams.get('token');
@@ -9,7 +10,7 @@ export async function GET(request: NextRequest) {
   // トークンが設定されていない、または一致しない場合は拒否
   // 開発環境ではトークンチェックをスキップすることも可能ですが、
   // 安全のため設定を推奨します。
-  if (!secret || token !== secret) {
+  if (!safeEqual(token, secret)) {
     return NextResponse.json({ message: 'Invalid token' }, { status: 401 });
   }
 

--- a/src/app/api/tts/route.ts
+++ b/src/app/api/tts/route.ts
@@ -3,7 +3,7 @@ import { Ratelimit } from "@upstash/ratelimit";
 import { getRedis } from "@/lib/upstash";
 import { getWordBySlug } from "@/data/words";
 import { getWordDetail } from "@/data/word-detail";
-import { ttsCacheKey, matchesExample } from "@/lib/tts-utils";
+import { ttsCacheKey, matchesExample, isSameHost } from "@/lib/tts-utils";
 
 async function isAllowedExampleText(
   text: string,
@@ -47,7 +47,7 @@ export async function POST(request: Request) {
   const host = request.headers.get("host");
 
   if (host) {
-    const allowed = (origin && origin.includes(host)) || (referer && referer.includes(host));
+    const allowed = isSameHost(origin, host) || isSameHost(referer, host);
     if (!allowed) {
       return Response.json({ error: "Unauthorized origin" }, { status: 403 });
     }

--- a/src/lib/(tests)/safe-compare.test.ts
+++ b/src/lib/(tests)/safe-compare.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { safeEqual } from "../safe-compare";
+
+describe("safeEqual", () => {
+  it("returns true for identical non-empty strings", () => {
+    expect(safeEqual("super-secret-token", "super-secret-token")).toBe(true);
+  });
+
+  it("returns false for differing strings", () => {
+    expect(safeEqual("super-secret-token", "wrong-token")).toBe(false);
+  });
+
+  it("returns false when lengths differ", () => {
+    expect(safeEqual("abc", "abcd")).toBe(false);
+  });
+
+  it("returns false when either side is missing", () => {
+    expect(safeEqual(null, "token")).toBe(false);
+    expect(safeEqual("token", undefined)).toBe(false);
+    expect(safeEqual(null, null)).toBe(false);
+  });
+
+  it("returns false for empty strings (treated as unset)", () => {
+    expect(safeEqual("", "")).toBe(false);
+    expect(safeEqual("", "token")).toBe(false);
+  });
+});

--- a/src/lib/(tests)/tts-utils.test.ts
+++ b/src/lib/(tests)/tts-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { normalizeText, sanitizeSlug, ttsCacheKey, matchesExample } from "../tts-utils";
+import { normalizeText, sanitizeSlug, ttsCacheKey, matchesExample, isSameHost } from "../tts-utils";
 import type { WordDetails } from "@/types/word";
 
 describe("normalizeText", () => {
@@ -91,5 +91,30 @@ describe("matchesExample", () => {
   it("rejects when language does not match the field", () => {
     // English text checked against the Japanese side should not match
     expect(matchesExample(detail, "We respect the deadline.", "ja")).toBe(false);
+  });
+});
+
+describe("isSameHost", () => {
+  it("accepts an origin whose host strictly equals the request host", () => {
+    expect(isSameHost("https://toeic-words.com", "toeic-words.com")).toBe(true);
+  });
+
+  it("matches host including port", () => {
+    expect(isSameHost("http://localhost:3000", "localhost:3000")).toBe(true);
+  });
+
+  it("rejects a suffix-style spoofed host", () => {
+    expect(isSameHost("https://toeic-words.com.attacker.com", "toeic-words.com")).toBe(false);
+  });
+
+  it("rejects a prefix-style spoofed host", () => {
+    expect(isSameHost("https://attacker.com/toeic-words.com", "toeic-words.com")).toBe(false);
+  });
+
+  it("returns false for unparseable headers or missing values", () => {
+    expect(isSameHost("not a url", "toeic-words.com")).toBe(false);
+    expect(isSameHost(null, "toeic-words.com")).toBe(false);
+    expect(isSameHost("https://toeic-words.com", null)).toBe(false);
+    expect(isSameHost(undefined, undefined)).toBe(false);
   });
 });

--- a/src/lib/safe-compare.ts
+++ b/src/lib/safe-compare.ts
@@ -1,0 +1,19 @@
+import { createHash, timingSafeEqual } from "crypto";
+
+/**
+ * トークン比較のタイミング攻撃対策。
+ * 早期リターンする `a === b` と異なり、入力長に依存しない一定時間で比較する。
+ * 両者を SHA-256 でハッシュ化してから固定長バッファ同士で比較することで、
+ * 長さの違いから情報が漏れることも防ぐ。
+ *
+ * `server-only` や外部依存を持たない純粋ロジックのため単体テスト可能。
+ */
+export function safeEqual(
+  a: string | null | undefined,
+  b: string | null | undefined
+): boolean {
+  if (!a || !b) return false;
+  const ha = createHash("sha256").update(a).digest();
+  const hb = createHash("sha256").update(b).digest();
+  return timingSafeEqual(ha, hb);
+}

--- a/src/lib/tts-utils.ts
+++ b/src/lib/tts-utils.ts
@@ -37,6 +37,24 @@ export function ttsCacheKey(text: string, language: string, wordSlug?: string): 
 }
 
 /**
+ * Origin/Referer ヘッダの host が、リクエストの host と厳密に一致するか判定する。
+ * `header.includes(host)` のような部分一致は
+ * `https://www.example.com.attacker.com` のような文字列を誤って許可してしまうため、
+ * URL としてパースした host 同士で厳密比較する。パース不能な場合は false。
+ */
+export function isSameHost(
+  header: string | null | undefined,
+  host: string | null | undefined
+): boolean {
+  if (!header || !host) return false;
+  try {
+    return new URL(header).host === host;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * 指定テキストが、単語詳細内の既知の例文（toeicExamples もしくは
  * meanings[].detailedMeanings[].example）と空白正規化後に一致するか判定する。
  */


### PR DESCRIPTION
1. CI に typecheck ステップ追加: package.json に typecheck (tsc --noEmit) を追加し、.github/workflows/ci.yml で実行。型エラー/本番ビルド破壊が lint/test をすり抜けないようにする（Blob/Gemini キー不要で実行可能）。
2. revalidate 系トークン比較をタイミング安全に: src/lib/safe-compare.ts の safeEqual（SHA-256 後に crypto.timingSafeEqual）に置換。
3. TTS の Origin/Referer 検証を部分一致から厳密一致へ: src/lib/tts-utils.ts の isSameHost（new URL().host 比較）を使用。
4. README / 技術ドキュメントの AI SDK 表記を実態（@google/genai の GoogleGenAI）に修正。最終更新日も更新。

safe-compare と isSameHost の単体テストを追加（計 +10、49 件 pass）。