### PR TITLE
refactor(study): StudyClient を純粋ロジック・フック・サブコンポーネントに分割

### DIFF
--- a/.trae/documents/技術ドキュメント.md
+++ b/.trae/documents/技術ドキュメント.md
@@ -1,6 +1,6 @@
 # TOEIC重要単語（toeic_website_ver2.0）技術ドキュメント
 
-最終更新日: 2026-07-14（Google検索向けサイト名のみ「TOEIC語彙ラボ」に変更）
+最終更新日: 2026-07-19（学習モード `StudyClient.tsx` のリファクタリング：純粋ロジック抽出＋コンポーネント/フック分割）
 
 ## 1. プロジェクト概要
 
@@ -412,6 +412,9 @@
   * カードの表裏を切り替えるUIと、カウントダウン表示によるリズム制御を行う
   * 「ヒントを見る」操作でAI詳細（`fetchWordDetail`）から例文を1件取得し、裏面に表示する
   * 学習状況は `sessionStorage` に保存し、戻る/進むでも継続しやすくする
+  * `StudyClient.tsx` は状態のオーケストレーションに専念し、UI は同ディレクトリの `StudyCard` / `StudyActions` / `LaterWordsSidebar` / `HintExample` / `AutoResizingText` に分割
+  * カウントダウン＋BFCache 復元時の維持判定は `src/hooks/useStudyCountdown.ts`、学習進捗（覚えた/覚えていない/あとで・連続正解数）と `sessionStorage` 永続化は `src/hooks/useStudyProgress.ts` が担当
+  * 出題選定（連続正解数による難易度プール選択・同一単語の再抽選・順番出題）、保存状態のパース、例文ハイライト分割などの純粋ロジックは `src/lib/study-utils.ts` に集約（ユニットテスト対象）
 
 * 静的ページ・法的文書 `src/app/(about|privacy|terms|contact|donate)/page.tsx`
   * アプリの概要、プライバシーポリシー、利用規約、お問い合わせ、寄付のお願いページを提供する
@@ -763,6 +766,9 @@ export type WordDetails = {
   * `word-detail-parse.test.ts` — Gemini 応答の JSON 抽出（コードフェンス除去・truncation 検知）と正規化（既定値補完・件数上限）
   * `tts-utils.test.ts` — テキスト正規化、slug サニタイズ、TTS キャッシュキー生成、例文 allowlist マッチング
   * `listen-utils.test.ts` — 聞き流しモードの `pickExample` フォールバック
+  * `favorites-sync.test.ts` — お気に入り同期（保存データのパース、マージ、マージ可否判定、upsert 行の構築）
+  * `safe-compare.test.ts` — トークンの定数時間比較（`safeEqual`）
+  * `study-utils.test.ts` — 学習モードの出題選定（連続正解数による難易度プール選択・同一単語の再抽選・順番出題）、`sessionStorage` 保存状態のパース、例文ハイライト分割（乱数は注入式にして全分岐を決定的に検証）
 * Gemini/Redis/Blob/TTS を必要とするもの、React コンポーネントの描画は **ユニットテストの対象外**（下記の手動テストで担保）。
 
 #### 手動テスト
@@ -875,3 +881,4 @@ export type WordDetails = {
 | 2026-07-12 | 4.5 | -   | Supabase による任意ログイン + お気に入り同期（Phase 1、`__docs__/phase1-login-favorites-sync-setup.md` 準拠）を追加。(1) `@supabase/supabase-js` + `@supabase/ssr` を導入し、`src/lib/supabase/client.ts`（ブラウザ）/ `server.ts`（サーバー、`server-only`）を新設。(2) `src/proxy.ts` を有効化（旧 `proxy.ts.disabled` を置換）。Supabase セッションリフレッシュ専用とし、Vercel Proxy 実行量を抑えるため matcher は `/login` と `/auth/*` に最小化。認証状態の表示はクライアント側 `onAuthStateChange`（`src/context/AuthContext.tsx`）で解決し、既存ページの静的キャッシュ（PPR/SSG）を維持。(3) `/login`（Google ログインのみ・noindex）と `/auth/callback`（認可コード交換）を追加。ログイン状態はTOP右上の `AuthStatus` と Footer に表示。(4) `FavoritesContext` を拡張：未ログイン時は従来どおり localStorage（キー `toeic_favorites`）、ログイン時は Supabase `favorites` テーブル（RLS で本人のみアクセス可）を楽観的更新で読み書き。初回ログイン時に localStorage のお気に入りを upsert（`ignoreDuplicates`）でマージし、成功時のみ localStorage を削除 + `toeic_favorites_merged_at` を記録（失敗時は残置し次回再マージ）。ログアウト時はアカウントのお気に入りを localStorage へ書き戻し、ログアウト後も同じお気に入りが見え続けるようにする（当初は書き戻さない方針だったが、スモークテストで「消えたように見える」と判明し改定）。書き戻し時には持ち主のユーザー ID を `toeic_favorites_owner` に記録し、ログイン時に照合（`shouldMergeLocalFavorites`）して「印なし（ゲスト）or 本人」のみマージ。別人の印が付いたデータはマージも表示合流もせず、共用ブラウザでのアカウント切替時に他人のお気に入りが自アカウントへ混入するのを防ぐ。純ロジックは `src/lib/favorites-sync.ts` に切り出し、`src/lib/(tests)/favorites-sync.test.ts` でユニットテスト。(5) プライバシーポリシー・About・TOP・寄付ページの「会員登録なし」文言を「ログイン任意（ログイン時はアカウント情報とお気に入りを Supabase に保存）」の記述へ更新。DB スキーマ（`profiles` / `favorites` + RLS + トリガー）は Supabase SQL Editor で適用済み（定義は上記 setup ドキュメント §3-2）。 |
 | 2026-07-12 | 4.6 | -   | `/login` の未ログイン表示に、ログイン済み表示と同じスタイルの「トップへ戻る」ボタンを追加。 |
 | 2026-07-14 | 4.7 | -   | Google検索結果のサイト名候補だけを「TOEIC語彙ラボ」に変更。対象を初期HTMLへ直接出力する `WebSite.name`、`og:site_name`、Next.js `applicationName` に限定し、SEOタイトル・description・H1・canonical・子ページタイトル末尾・publisher/author・PWA/OGP表記は従来の「TOEIC重要単語」を維持。「TOEIC 最新単語」「TOEIC重要単語」の既存順位への影響を抑えるため、TOPの小ラベルとFooterのみ両名称を併記。 |
+| 2026-07-19 | 4.8 | -   | 学習モード `StudyClient.tsx`（728行、SonarCloud 認知的複雑度41、ESLint `react-hooks/exhaustive-deps` 警告5件）を挙動変更なしでリファクタリング。(1) 出題選定（連続正解数による難易度プール選択 `selectWordPool`・同一単語の再抽選 `pickRandomStudyWord`・順番出題 `pickSequentialStudyWord`）、`sessionStorage` 保存状態のパース `parsePersistedStudyState`、例文ハイライト分割 `splitSentenceByTerm` などの純粋ロジックを `src/lib/study-utils.ts` へ抽出し、`src/lib/(tests)/study-utils.test.ts` に40件のユニットテストを追加（乱数を注入式にして難易度分岐を決定的に検証）。(2) UI を `StudyCard` / `StudyActions` / `LaterWordsSidebar` / `HintExample` / `AutoResizingText`（`src/components/features/study/`）に分割し、カウントダウン＋BFCache 復元判定を `useStudyCountdown`、学習進捗＋永続化を `useStudyProgress` フックへ分離。関数を effect 内またはモジュールスコープへ移す構造で ESLint 警告5件を解消（React Compiler 方針に従い手動 `useCallback` は不使用）。`StudyClient.tsx` は 262 行のオーケストレーターになった。 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Any feature change must update **both** `README.md` and `.trae/documents/技術�
 ### Testing
 **Unit tests (Vitest) cover pure logic only**; integration/UI is still verified by manual smoke test.
 
-- Pure, side-effect-free logic lives in `src/lib/*.ts` and is unit-tested in `src/lib/(tests)/*.test.ts` files (`environment: "node"`, no secrets required). Current suites: `word-select` (parsing/dedup, FNV-1a hash, JST day key, daily selection), `word-detail-parse` (Gemini JSON extraction + normalization), `tts-utils` (text normalization, slug sanitization, cache keys, example allowlist matching), `listen-utils` (`pickExample` fallback).
+- Pure, side-effect-free logic lives in `src/lib/*.ts` and is unit-tested in `src/lib/(tests)/*.test.ts` files (`environment: "node"`, no secrets required). Current suites: `word-select` (parsing/dedup, FNV-1a hash, JST day key, daily selection), `word-detail-parse` (Gemini JSON extraction + normalization), `tts-utils` (text normalization, slug sanitization, cache keys, example allowlist matching), `listen-utils` (`pickExample` fallback), `favorites-sync` (stored-favorites parsing, merge logic), `safe-compare` (constant-time token comparison), `study-utils` (study-mode pool selection/re-draw with injectable random, persisted-state parsing, sentence highlight splitting).
 - When extracting testable logic out of a `server-only` module, put the pure function in `src/lib/` (no `server-only`, type-only imports for server types) and have the server module import it — never duplicate.
 - Do **not** add tests that require Gemini/Redis/Blob/TTS or render React components; cover those by manual testing.
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ TOEIC語彙ラボ is a comprehensive web application for learning essential TOEI
 - `npm run build`: Builds the application for production.
 - `npm run start`: Starts the production server.
 - `npm run lint`: Runs ESLint.
-- `npm run test`: Runs Vitest unit tests. These cover **pure logic only** (word selection/parsing, Gemini response normalization, TTS cache keys & example allowlist, listen-mode example fallback) and run in CI alongside `npm run lint`. Integration and UI changes are still verified by manual smoke testing.
+- `npm run test`: Runs Vitest unit tests. These cover **pure logic only** (word selection/parsing, Gemini response normalization, TTS cache keys & example allowlist, listen-mode example fallback, favorites sync/merge, study-mode word selection & persisted-state parsing) and run in CI alongside `npm run lint`. Integration and UI changes are still verified by manual smoke testing.
 
 ## 🔄 API Endpoints
 

--- a/src/components/features/study/AutoResizingText.tsx
+++ b/src/components/features/study/AutoResizingText.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+type Props = {
+  text: string;
+  className?: string;
+  style?: React.CSSProperties;
+};
+
+// 親要素の幅に収まるまでフォントサイズを段階的に縮小するテキスト。
+// 最小サイズまで縮小しても収まらない場合は折り返しに切り替える。
+export default function AutoResizingText({ text, className, style }: Props) {
+  const ref = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    const adjustSize = () => {
+      const el = ref.current;
+      if (!el) return;
+
+      const parent = el.parentElement;
+      if (!parent || parent.clientWidth === 0) return;
+
+      // 自然な幅を正確に測るため、幅制限や省略記号のスタイルを一時的に解除する
+      el.style.maxWidth = 'none';
+      el.style.overflow = 'visible';
+      el.style.textOverflow = 'clip';
+      el.style.whiteSpace = 'nowrap';
+
+      let size = 48; // CSS のデフォルトサイズ
+      el.style.fontSize = `${size}px`;
+
+      const maxWidth = parent.clientWidth - 10;
+
+      while (el.scrollWidth > maxWidth && size > 16) {
+        size -= 2;
+        el.style.fontSize = `${size}px`;
+      }
+
+      // 最小サイズでも収まらない場合は折り返す
+      if (el.scrollWidth > maxWidth) {
+        el.style.whiteSpace = 'normal';
+        el.style.wordBreak = 'break-word';
+      }
+      el.style.maxWidth = '100%';
+    };
+
+    adjustSize();
+    window.addEventListener('resize', adjustSize);
+    return () => window.removeEventListener('resize', adjustSize);
+  }, [text]);
+
+  return <span ref={ref} className={className} style={style}>{text}</span>;
+}

--- a/src/components/features/study/HintExample.tsx
+++ b/src/components/features/study/HintExample.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Loader2, Volume2 } from 'lucide-react';
+import { splitSentenceByTerm } from '@/lib/study-utils';
+
+type Props = {
+  sentence: string;
+  term: string;
+  slug: string;
+  sentenceAudioLoading: string | null;
+  onPlaySentenceAudio: (text: string, id: string, language: string, wordSlug?: string) => void;
+};
+
+// ヒント例文。対象単語（活用形を含む）をハイライトし、読み上げボタンを添える。
+export default function HintExample({ sentence, term, slug, sentenceAudioLoading, onPlaySentenceAudio }: Props) {
+  const audioId = `hint-example-${slug}`;
+  const isLoading = sentenceAudioLoading === audioId;
+  const parts = splitSentenceByTerm(sentence, term);
+
+  return (
+    <div className="flex flex-col items-center gap-1 w-full">
+      <div className="text-xl text-gray-700 text-center leading-[1.6] font-medium max-w-[90%]">
+        <span className="text-emerald-600 font-extrabold text-[1.1em] mr-2">Sample:</span>
+        {parts.map((part, i) =>
+          part.isMatch ? (
+            <span key={i} className="text-gray-900 font-extrabold underline decoration-amber-300 decoration-[3px] bg-amber-200/30 px-[2px] rounded-[2px]">{part.text}</span>
+          ) : (
+            <span key={i}>{part.text}</span>
+          )
+        )}
+        <button
+          className="inline-flex items-center justify-center p-0 border-none bg-transparent cursor-pointer align-middle disabled:opacity-70 disabled:cursor-default ml-2 group"
+          onClick={() => onPlaySentenceAudio(sentence, audioId, 'en', slug)}
+          disabled={isLoading}
+          aria-label="Play sample audio"
+          style={{ marginLeft: '8px', verticalAlign: 'middle', display: 'inline-flex' }}
+        >
+          <span className="w-[26px] h-[26px] rounded-full inline-flex items-center justify-center bg-gray-100 text-[#5780d8] text-lg leading-none transition-all duration-160 group-hover:translate-y-[-1px] group-hover:shadow-md">
+            {isLoading ? (
+              <Loader2 className="animate-spin" size={14} />
+            ) : (
+              <Volume2 size={14} />
+            )}
+          </span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/study/LaterWordsSidebar.tsx
+++ b/src/components/features/study/LaterWordsSidebar.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { Clock3 } from 'lucide-react';
+import type { Word } from '@/data/words';
+
+const LEVEL_LABELS: Record<Word['level'], string> = {
+  important: '重要',
+  medium: '中級',
+  high: '上級',
+};
+
+type Props = {
+  words: Word[];
+  currentSlug: string;
+  onSelect: (word: Word) => void;
+};
+
+// 「あとで確認」に積んだ単語の一覧サイドバー。クリックでその単語をカードに表示する。
+export default function LaterWordsSidebar({ words, currentSlug, onSelect }: Props) {
+  return (
+    <aside className="w-full rounded-3xl border border-gray-200 bg-white/90 p-5 shadow-[0_10px_25px_rgba(15,23,42,0.08)] backdrop-blur-sm lg:sticky lg:top-8">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-amber-100 text-amber-700">
+            <Clock3 size={18} strokeWidth={2.4} />
+          </span>
+          <div>
+            <h2 className="text-base font-bold leading-tight text-slate-900">あとで確認</h2>
+            <p className="text-xs font-medium text-slate-500">{words.length}語を保留中</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="max-h-[420px] space-y-2 overflow-y-auto pr-1">
+        {words.map((word) => {
+          const isActive = currentSlug === word.slug;
+
+          return (
+            <button
+              key={word.slug}
+              type="button"
+              onClick={() => onSelect(word)}
+              className={`group flex w-full items-center justify-between gap-3 rounded-2xl border px-3.5 py-3 text-left transition-all duration-200 ${
+                isActive
+                  ? 'border-blue-300 bg-blue-50 text-blue-900 shadow-sm'
+                  : 'border-slate-200 bg-white text-slate-700 hover:border-amber-300 hover:bg-amber-50 hover:-translate-y-0.5 hover:shadow-sm'
+              }`}
+              aria-current={isActive ? 'true' : undefined}
+            >
+              <span className="min-w-0">
+                <span className="block truncate text-sm font-bold">{word.term}</span>
+                <span className="mt-0.5 block text-xs font-medium text-slate-500">
+                  {LEVEL_LABELS[word.level]}
+                </span>
+              </span>
+              <span className={`shrink-0 rounded-full px-2 py-1 text-[11px] font-bold ${
+                isActive ? 'bg-blue-100 text-blue-700' : 'bg-slate-100 text-slate-500 group-hover:bg-amber-100 group-hover:text-amber-700'
+              }`}>
+                確認
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </aside>
+  );
+}

--- a/src/components/features/study/StudyActions.tsx
+++ b/src/components/features/study/StudyActions.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+type Props = {
+  onRemembered: () => void;
+  onForgot: () => void;
+  onLater: () => void;
+  showDifficultyTip: boolean;
+  consecutiveRememberCount: number;
+};
+
+// 「覚えている / 覚えていない / あとで」の 3 ボタンと難易度アップのヒント表示。
+export default function StudyActions({
+  onRemembered,
+  onForgot,
+  onLater,
+  showDifficultyTip,
+  consecutiveRememberCount,
+}: Props) {
+  return (
+    <section className="flex flex-col items-center w-full mt-0">
+      <div className="flex flex-wrap gap-4 w-full justify-center sm:gap-6">
+        <button
+          className="flex flex-col items-center justify-center gap-2 w-24 h-24 rounded-full border-none cursor-pointer transition-all duration-200 shadow-sm bg-green-200 text-green-900 border-2 border-green-300 hover:bg-green-300 hover:-translate-y-0.5 hover:shadow-md active:translate-y-0 sm:h-[120px] sm:w-[120px]"
+          onClick={onRemembered}
+          aria-label="覚えている"
+        >
+          <span className="text-[32px] font-bold">💡</span>
+          <span className="text-[10px] font-semibold leading-none sm:text-sm">覚えている</span>
+        </button>
+
+        <button
+          className="flex flex-col items-center justify-center gap-2 w-24 h-24 rounded-full border-none cursor-pointer transition-all duration-200 shadow-sm bg-red-200 text-red-900 border-2 border-red-300 hover:bg-red-300 hover:-translate-y-0.5 hover:shadow-md active:translate-y-0 sm:h-[120px] sm:w-[120px]"
+          onClick={onForgot}
+          aria-label="覚えていない"
+        >
+          <span className="text-[32px] font-bold">❔</span>
+          <span className="text-[10px] font-semibold leading-none sm:text-sm">覚えていない</span>
+        </button>
+
+        <button
+          className="flex flex-col items-center justify-center gap-2 w-24 h-24 rounded-full border-none cursor-pointer transition-all duration-200 shadow-sm bg-amber-100 text-amber-900 border-2 border-amber-300 hover:bg-amber-200 hover:-translate-y-0.5 hover:shadow-md active:translate-y-0 sm:h-[120px] sm:w-[120px]"
+          onClick={onLater}
+          aria-label="あとで確認"
+        >
+          <span className="text-[32px] font-bold">⏰</span>
+          <span className="text-[10px] font-semibold leading-none sm:text-sm">あとで</span>
+        </button>
+      </div>
+
+      {showDifficultyTip && (
+        <div className="mt-8 flex items-center gap-2 text-[13px] font-medium text-slate-500 bg-white/50 px-4 py-2 rounded-full border border-slate-200 shadow-sm backdrop-blur-sm transition-all duration-300">
+          <span className="text-amber-500 text-base leading-none">💡</span>
+          <span>連続で「覚えている」を選ぶと難易度が上がります</span>
+          {consecutiveRememberCount > 0 && (
+            <span className="ml-1 px-2 py-0.5 bg-emerald-100 text-emerald-700 rounded-full text-xs font-bold animate-pulse">
+              {consecutiveRememberCount}連続中 🔥
+            </span>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/features/study/StudyCard.tsx
+++ b/src/components/features/study/StudyCard.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { Star, Volume2, Loader2 } from 'lucide-react';
+import type { Word } from '@/data/words';
+import AutoResizingText from './AutoResizingText';
+import HintExample from './HintExample';
+
+type Props = {
+  cardRef: React.RefObject<HTMLElement | null>;
+  word: Word;
+  isFlipped: boolean;
+  isLoadingHint: boolean;
+  hintExample: string | null;
+  countdownValue: number | null;
+  countdownKey: number;
+  showHintButton: boolean;
+  isFavorite: boolean;
+  audioLoading: boolean;
+  sentenceAudioLoading: string | null;
+  onHint: () => void;
+  onToggleFavorite: () => void;
+  onPlayWordAudio: () => void;
+  onPlaySentenceAudio: (text: string, id: string, language: string, wordSlug?: string) => void;
+};
+
+// 学習カード本体。表面は単語のみ、裏面（ヒント表示後）は単語 + 例文 + 音声ボタン。
+// カウントダウン・ヒントボタン・お気に入りボタンをオーバーレイ表示する。
+export default function StudyCard({
+  cardRef,
+  word,
+  isFlipped,
+  isLoadingHint,
+  hintExample,
+  countdownValue,
+  countdownKey,
+  showHintButton,
+  isFavorite,
+  audioLoading,
+  sentenceAudioLoading,
+  onHint,
+  onToggleFavorite,
+  onPlayWordAudio,
+  onPlaySentenceAudio,
+}: Props) {
+  return (
+    <section ref={cardRef} className="w-full perspective-[1000px] relative">
+      <div className={`flex flex-col justify-center items-center px-6 py-12 rounded-3xl bg-white/95 border border-gray-200 shadow-[0_10px_25px_rgba(15,23,42,0.08)] transition-all duration-300 min-h-[225px] ${isFlipped ? 'animate-flipIn' : ''}`}>
+        {!isFlipped ? (
+          <div style={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
+            <AutoResizingText text={word.term} className="text-5xl font-bold text-gray-900 text-center mb-3 whitespace-nowrap max-w-full overflow-hidden text-ellipsis" />
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-4 w-full animate-flipIn">
+            <div className="flex items-center justify-center gap-3 w-full max-w-full">
+              <div style={{ minWidth: 0, display: 'flex', justifyContent: 'center' }}>
+                <AutoResizingText text={word.term} className="text-5xl font-bold text-gray-900 text-center mb-0 whitespace-nowrap max-w-full overflow-hidden text-ellipsis" style={{ marginBottom: 0 }} />
+              </div>
+              <button
+                className="inline-flex items-center justify-center p-0 border-none bg-transparent cursor-pointer disabled:opacity-70 disabled:cursor-default align-middle group"
+                onClick={onPlayWordAudio}
+                disabled={audioLoading}
+                aria-label="Play word audio"
+              >
+                <span className="w-[26px] h-[26px] rounded-full inline-flex items-center justify-center bg-gray-100 text-[#5780d8] text-lg leading-none transition-all duration-160 group-hover:translate-y-[-1px] group-hover:shadow-md">
+                  {audioLoading ? (
+                    <Loader2 className="animate-spin" size={14} />
+                  ) : (
+                    <Volume2 size={14} />
+                  )}
+                </span>
+              </button>
+            </div>
+            {isLoadingHint ? (
+              <div className="flex flex-col items-center gap-1 w-full">
+                <div className="h-5 w-[80%] mx-auto mb-2 bg-blue-100 rounded relative overflow-hidden after:content-[''] after:absolute after:inset-0 after:-translate-x-full after:animate-shimmer after:bg-gradient-to-r after:from-transparent after:via-white/50 after:to-transparent" />
+                <div className="h-5 w-[60%] mx-auto mb-2 bg-blue-100 rounded relative overflow-hidden after:content-[''] after:absolute after:inset-0 after:-translate-x-full after:animate-shimmer after:bg-gradient-to-r after:from-transparent after:via-white/50 after:to-transparent" />
+              </div>
+            ) : (
+              hintExample && (
+                <HintExample
+                  sentence={hintExample}
+                  term={word.term}
+                  slug={word.slug}
+                  sentenceAudioLoading={sentenceAudioLoading}
+                  onPlaySentenceAudio={onPlaySentenceAudio}
+                />
+              )
+            )}
+          </div>
+        )}
+      </div>
+      {countdownValue !== null && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-30" aria-hidden="true">
+          <div key={countdownKey} className={`inline-block text-[140px] leading-none font-black drop-shadow-lg animate-countdownCenter ${countdownValue === 2 ? 'text-amber-500/40' : 'text-red-500/40'}`}>
+            {countdownValue}
+          </div>
+        </div>
+      )}
+      {showHintButton && !isFlipped && (
+        <div className="absolute inset-0 flex items-start justify-end p-3.5 pointer-events-none z-20 sm:p-2.5">
+          <button
+            onClick={onHint}
+            className="pointer-events-auto relative flex items-center justify-center px-5 py-2.5 bg-white text-slate-700 border-2 border-amber-300 rounded-full text-sm font-bold cursor-pointer transition-all duration-200 shadow-[0_0_15px_rgba(251,191,36,0.3)] hover:bg-amber-50 hover:-translate-y-1 hover:shadow-[0_0_20px_rgba(251,191,36,0.5)] animate-hintPop overflow-hidden group"
+          >
+            <span className="relative z-10 flex items-center gap-1.5">
+              <span className="animate-pulse text-base">💡</span> ヒントを見る
+            </span>
+            <div className="absolute inset-0 rounded-full bg-amber-200/30 animate-ping opacity-75"></div>
+          </button>
+        </div>
+      )}
+      {isFlipped && (
+        <div className="absolute inset-0 flex items-start justify-end p-3.5 pointer-events-none z-20 sm:p-2.5">
+          <button
+            onClick={onToggleFavorite}
+            className="pointer-events-auto inline-flex items-center justify-center w-11 h-11 rounded-full border border-gray-200 bg-white text-slate-500 cursor-pointer transition-all duration-200 shadow-sm shrink-0 hover:bg-slate-50 hover:border-slate-300 hover:-translate-y-px hover:shadow-md active:translate-y-0"
+            aria-label={isFavorite ? 'お気に入りから削除' : 'お気に入りに追加'}
+          >
+            <Star
+              size={24}
+              fill={isFavorite ? '#FFC107' : 'none'}
+              color={isFavorite ? '#FFC107' : '#94a3b8'}
+              strokeWidth={2}
+            />
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/features/study/StudyClient.tsx
+++ b/src/components/features/study/StudyClient.tsx
@@ -3,11 +3,23 @@
 import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { Star, Volume2, Loader2, ChevronLeft, Clock3 } from 'lucide-react';
+import { ChevronLeft } from 'lucide-react';
 import { useFavorites } from '@/context/FavoritesContext';
 import type { Word } from '@/data/words';
 import { fetchWordDetail } from '@/actions/word';
 import { useTTS } from '@/hooks/useTTS';
+import { useStudyCountdown } from '@/hooks/useStudyCountdown';
+import { useStudyProgress, readPersistedState, clearPersistedState } from '@/hooks/useStudyProgress';
+import {
+  buildWordMap,
+  getNavigationType,
+  splitWordsByLevel,
+  pickRandomStudyWord,
+  pickSequentialStudyWord,
+} from '@/lib/study-utils';
+import StudyCard from './StudyCard';
+import StudyActions from './StudyActions';
+import LaterWordsSidebar from './LaterWordsSidebar';
 
 type Props = {
   words: Word[];
@@ -18,128 +30,13 @@ type Props = {
   order?: 'random' | 'sequential';
 };
 
-type PersistedStudyStateV1 = {
-  v: 1;
-  currentSlug: string;
-  rememberedSlugs: string[];
-  forgottenSlugs: string[];
-  laterSlugs?: string[];
-  consecutiveRememberCount?: number;
-  updatedAt: number;
-};
-
 const DEFAULT_STORAGE_KEY = 'toeic-study-state-v1';
 const DEFAULT_PAGE_TITLE = '英単語学習';
 const DEFAULT_BACK_LINK = '/';
 const DEFAULT_BACK_LINK_TEXT = '単語一覧';
 
-function getNavigationType(): string | undefined {
-  if (typeof window === 'undefined') return undefined;
-  const entry = window.performance.getEntriesByType('navigation')[0];
-  if (!entry) return undefined;
-  if ('type' in entry) {
-    return (entry as PerformanceNavigationTiming).type;
-  }
-  return undefined;
-}
-
-function parsePersistedStudyState(raw: string): PersistedStudyStateV1 | null {
-  try {
-    const data = JSON.parse(raw) as unknown;
-    if (!data || typeof data !== 'object') return null;
-    const obj = data as Record<string, unknown>;
-    if (obj.v !== 1) return null;
-    if (typeof obj.currentSlug !== 'string') return null;
-    if (!Array.isArray(obj.rememberedSlugs) || !obj.rememberedSlugs.every((s) => typeof s === 'string')) {
-      return null;
-    }
-    if (!Array.isArray(obj.forgottenSlugs) || !obj.forgottenSlugs.every((s) => typeof s === 'string')) {
-      return null;
-    }
-    if (obj.laterSlugs !== undefined && (!Array.isArray(obj.laterSlugs) || !obj.laterSlugs.every((s) => typeof s === 'string'))) {
-      return null;
-    }
-    if (obj.consecutiveRememberCount !== undefined && typeof obj.consecutiveRememberCount !== 'number') return null;
-    if (typeof obj.updatedAt !== 'number') return null;
-    return obj as PersistedStudyStateV1;
-  } catch {
-    return null;
-  }
-}
-
-function uniqueStrings(values: string[]): string[] {
-  return Array.from(new Set(values));
-}
-
-function addUnique(values: string[], value: string): string[] {
-  if (values.includes(value)) return values;
-  return [...values, value];
-}
-
-function removeValue(values: string[], value: string): string[] {
-  return values.filter((v) => v !== value);
-}
-
-function escapeRegExp(string: string) {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-// AutoResizingText Component
-const AutoResizingText = ({ text, className, style }: { text: string, className?: string, style?: React.CSSProperties }) => {
-  const ref = useRef<HTMLSpanElement>(null);
-  
-  const adjustSize = () => {
-    const el = ref.current;
-    if (!el) return;
-    
-    const parent = el.parentElement;
-    // If parent is not available or has 0 width (hidden), skip
-    if (!parent || parent.clientWidth === 0) return;
-
-    // Force styles to allow accurate measurement of natural width
-    // We override class styles that might constrain width or show ellipsis
-    el.style.maxWidth = 'none';
-    el.style.overflow = 'visible';
-    el.style.textOverflow = 'clip';
-    el.style.whiteSpace = 'nowrap';
-    
-    let size = 48; // default from css
-    el.style.fontSize = `${size}px`;
-    
-    // Let's use a safe margin.
-    const maxWidth = parent.clientWidth - 10; 
-
-    while (el.scrollWidth > maxWidth && size > 16) {
-      size -= 2;
-      el.style.fontSize = `${size}px`;
-    }
-    
-    // If still overflowing, allow wrap
-    if (el.scrollWidth > maxWidth) {
-       el.style.whiteSpace = 'normal';
-       el.style.wordBreak = 'break-word';
-       el.style.maxWidth = '100%';
-    } else {
-       // Fits! Ensure no ellipsis by keeping overflow visible, but constrain width just in case.
-       el.style.maxWidth = '100%';
-    }
-  };
-
-  useEffect(() => {
-    adjustSize();
-  }, [adjustSize]);
-
-  useEffect(() => {
-    const handleResize = () => adjustSize();
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, [adjustSize]);
-
-  return <span ref={ref} className={className} style={style}>{text}</span>;
-};
-
-export default function StudyClient({ 
-  words, 
+export default function StudyClient({
+  words,
   storageKey = DEFAULT_STORAGE_KEY,
   pageTitle = DEFAULT_PAGE_TITLE,
   backLink = DEFAULT_BACK_LINK,
@@ -149,19 +46,11 @@ export default function StudyClient({
   const router = useRouter();
   const { isFavorite, toggleFavorite } = useFavorites();
   const [currentWord, setCurrentWord] = useState<Word | null>(null);
-  const [rememberedSlugs, setRememberedSlugs] = useState<string[]>([]);
-  const [forgottenSlugs, setForgottenSlugs] = useState<string[]>([]);
-  const [laterSlugs, setLaterSlugs] = useState<string[]>([]);
-  const [consecutiveRememberCount, setConsecutiveRememberCount] = useState(0);
-  const initializedRef = useRef(false);
-  const cardRef = useRef<HTMLElement>(null);
-  const [countdownValue, setCountdownValue] = useState<number | null>(null);
-  const [countdownKey, setCountdownKey] = useState(0);
-  const countdownTimeoutsRef = useRef<number[]>([]);
-  const [showHintButton, setShowHintButton] = useState(false);
   const [hintExample, setHintExample] = useState<string | null>(null);
   const [isFlipped, setIsFlipped] = useState(false);
   const [isLoadingHint, setIsLoadingHint] = useState(false);
+  const initializedRef = useRef(false);
+  const cardRef = useRef<HTMLElement>(null);
 
   const {
     audioLoading,
@@ -170,342 +59,132 @@ export default function StudyClient({
     handlePlaySentenceAudio
   } = useTTS();
 
-  const mediumWords = words.filter(w => w.level === 'medium');
-  const importantWords = words.filter(w => w.level === 'important');
-  const highWords = words.filter(w => w.level === 'high');
+  const {
+    countdownValue,
+    countdownKey,
+    showHintButton,
+    setShowHintButton,
+    startCountdown,
+  } = useStudyCountdown(isFlipped);
 
-  const wordBySlug = (() => {
-    const map = new Map<string, Word>();
-    for (const w of words) {
-      map.set(w.slug, w);
-    }
-    return map;
-  })();
+  const {
+    laterSlugs,
+    consecutiveRememberCount,
+    markRemembered,
+    markForgot,
+    markLater,
+    restoreProgress,
+    resetProgress,
+  } = useStudyProgress(storageKey, currentWord?.slug ?? null);
+
+  const wordBySlug = buildWordMap(words);
 
   const laterWords = laterSlugs
     .map((slug) => wordBySlug.get(slug))
     .filter((word): word is Word => Boolean(word));
 
-  const clearCountdown = () => {
-    for (const id of countdownTimeoutsRef.current) {
-      clearTimeout(id);
-    }
-    countdownTimeoutsRef.current = [];
-    setCountdownValue(null);
-    setShowHintButton(false);
-  };
-
-  const startCountdown = () => {
-    for (const id of countdownTimeoutsRef.current) {
-      clearTimeout(id);
-    }
-    countdownTimeoutsRef.current = [];
-
-    // Count down from 2
-    setCountdownValue(2);
-    setShowHintButton(false);
+  /** カウントダウンを開始し、ヒント関連の状態をリセットする */
+  const startCardCountdown = () => {
+    startCountdown();
     setHintExample(null);
     setIsFlipped(false);
     setIsLoadingHint(false);
-    setCountdownKey((k) => k + 1);
-
-    const t1 = window.setTimeout(() => {
-      setCountdownValue(1);
-      setCountdownKey((k) => k + 1);
-    }, 1000);
-    const t0 = window.setTimeout(() => {
-      setCountdownValue(0);
-      setCountdownKey((k) => k + 1);
-    }, 2000);
-    const th = window.setTimeout(() => {
-      setCountdownValue(null);
-      setShowHintButton(true);
-    }, 2060); // 2s + 60ms
-
-    countdownTimeoutsRef.current = [t1, t0, th];
   };
 
-  const pickRandomWord = (overrideCount?: number) => {
+  /** 次の単語を選んで表示する（random は難易度調整付き） */
+  const advanceToNextWord = (overrideCount?: number) => {
     if (words.length === 0) return;
-
-    if (typeof window !== 'undefined') {
-      startCountdown();
-    }
-
-    let nextWord: Word;
-    const currentCount = overrideCount !== undefined ? overrideCount : consecutiveRememberCount;
-
-    if (order === 'sequential') {
-      if (!currentWord) {
-        nextWord = words[0];
-      } else {
-        const currentIndex = words.findIndex(w => w.slug === currentWord.slug);
-        const nextIndex = (currentIndex + 1) % words.length;
-        nextWord = words[nextIndex];
-      }
-    } else {
-      let safetyCounter = 0;
-      
-      // 現在の単語と同じ場合は再抽選する（リストが2つ以上ある場合のみ）
-      do {
-        let pool = words;
-
-        // 連続正解回数による段階的な難易度調整
-        // 0〜4回: important中心 (important 80%, medium 20%)
-        // 5〜9回: medium中心 (important 20%, medium 60%, high 20%)
-        // 10回〜: high中心 (important 10%, medium 30%, high 60%)
-        const r = Math.random();
-
-        if (currentCount < 5) {
-          if (r < 0.8 && importantWords.length > 0) pool = importantWords;
-          else if (mediumWords.length > 0) pool = mediumWords;
-          else if (highWords.length > 0) pool = highWords;
-        } else if (currentCount < 10) {
-          if (r < 0.6 && mediumWords.length > 0) pool = mediumWords;
-          else if (r < 0.8 && importantWords.length > 0) pool = importantWords;
-          else if (highWords.length > 0) pool = highWords;
-          else if (mediumWords.length > 0) pool = mediumWords;
-        } else {
-          if (r < 0.6 && highWords.length > 0) pool = highWords;
-          else if (r < 0.9 && mediumWords.length > 0) pool = mediumWords;
-          else if (importantWords.length > 0) pool = importantWords;
-          else if (highWords.length > 0) pool = highWords;
-        }
-
-        const randomIndex = Math.floor(Math.random() * pool.length);
-        nextWord = pool[randomIndex];
-        safetyCounter++;
-      } while (
-        words.length > 1 && 
-        currentWord && 
-        nextWord.slug === currentWord.slug && 
-        safetyCounter < 10
-      );
-    }
-
-    setCurrentWord(nextWord);
+    startCardCountdown();
+    const count = overrideCount ?? consecutiveRememberCount;
+    const next =
+      order === 'sequential'
+        ? pickSequentialStudyWord(words, currentWord?.slug ?? null)
+        : pickRandomStudyWord(splitWordsByLevel(words), currentWord?.slug ?? null, count);
+    if (next) setCurrentWord(next);
   };
 
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-
-    const onPageShow = (event: PageTransitionEvent) => {
-      // 戻るボタンでの遷移時、もし既にヒントボタンが表示されている(showHintButton=true)か、
-      // カードが裏返っている(isFlipped=true)場合は、状態をリセットしない。
-      // これにより、BFCacheで復元された場合でもヒントボタンの状態を維持する。
-      if (showHintButton || isFlipped) {
-        return;
-      }
-      if (event.persisted || getNavigationType() === 'back_forward') {
-        clearCountdown();
-      }
-    };
-
-    window.addEventListener('pageshow', onPageShow);
-    return () => {
-      window.removeEventListener('pageshow', onPageShow);
-      // clearCountdown(); // コンポーネントのアンマウント時にクリアすると戻るボタンで戻った時に消えてしまうため削除
-    };
-  }, [clearCountdown, showHintButton, isFlipped]);
-
+  // 初回マウント時: リロードなら状態を破棄し、それ以外は sessionStorage からの復元を試みる
   useEffect(() => {
     if (initializedRef.current) return;
     const timer = window.setTimeout(() => {
       if (initializedRef.current) return;
       initializedRef.current = true;
 
-      const navigationType = getNavigationType();
-
-      if (navigationType === 'reload') {
-        try {
-          window.sessionStorage.removeItem(storageKey);
-        } catch {
+      if (getNavigationType() === 'reload') {
+        clearPersistedState(storageKey);
+        resetProgress();
+      } else {
+        const persisted = readPersistedState(storageKey);
+        const word = persisted ? wordBySlug.get(persisted.currentSlug) : undefined;
+        if (persisted && word) {
+          setCurrentWord(word);
+          restoreProgress(persisted);
+          setShowHintButton(true);
+          return;
         }
-        setRememberedSlugs([]);
-        setForgottenSlugs([]);
-        setLaterSlugs([]);
-        pickRandomWord();
-        return;
       }
 
-      try {
-        const raw = window.sessionStorage.getItem(storageKey);
-        if (raw) {
-          const persisted = parsePersistedStudyState(raw);
-          if (persisted) {
-            const word = wordBySlug.get(persisted.currentSlug);
-            if (word) {
-              setCurrentWord(word);
-              setRememberedSlugs(uniqueStrings(persisted.rememberedSlugs));
-              setForgottenSlugs(uniqueStrings(persisted.forgottenSlugs));
-              setLaterSlugs(uniqueStrings(persisted.laterSlugs ?? []));
-              if (persisted.consecutiveRememberCount !== undefined) {
-                setConsecutiveRememberCount(persisted.consecutiveRememberCount);
-              }
-              setShowHintButton(true);
-              return;
-            }
-          }
-        }
-      } catch {
-      }
-
-      pickRandomWord();
+      if (words.length === 0) return;
+      startCountdown();
+      const first =
+        order === 'sequential'
+          ? pickSequentialStudyWord(words, null)
+          : pickRandomStudyWord(splitWordsByLevel(words), null, 0);
+      if (first) setCurrentWord(first);
     }, 0);
 
     return () => window.clearTimeout(timer);
-  }, [pickRandomWord, wordBySlug, storageKey]);
-
-  const writePersistedState = (
-    slug: string,
-    remembered: string[],
-    forgotten: string[],
-    later: string[],
-    count: number,
-  ) => {
-    if (typeof window === 'undefined') return;
-    try {
-      const nextState: PersistedStudyStateV1 = {
-        v: 1,
-        currentSlug: slug,
-        rememberedSlugs: remembered,
-        forgottenSlugs: forgotten,
-        laterSlugs: later,
-        consecutiveRememberCount: count,
-        updatedAt: Date.now(),
-      };
-      window.sessionStorage.setItem(storageKey, JSON.stringify(nextState));
-    } catch {}
-  };
-
-  useEffect(() => {
-    if (!currentWord) return;
-    writePersistedState(currentWord.slug, rememberedSlugs, forgottenSlugs, laterSlugs, consecutiveRememberCount);
-  }, [currentWord, rememberedSlugs, forgottenSlugs, laterSlugs, consecutiveRememberCount, writePersistedState]);
+  }, [words, order, storageKey, wordBySlug, restoreProgress, resetProgress, setShowHintButton, startCountdown]);
 
   const handleRemembered = () => {
     if (!currentWord) return;
-    setRememberedSlugs((prev) => addUnique(prev, currentWord.slug));
-    setForgottenSlugs((prev) => removeValue(prev, currentWord.slug));
-    setLaterSlugs((prev) => removeValue(prev, currentWord.slug));
-    const newCount = consecutiveRememberCount + 1;
-    setConsecutiveRememberCount(newCount);
-    pickRandomWord(newCount);
+    const newCount = markRemembered(currentWord.slug);
+    advanceToNextWord(newCount);
   };
 
   const handleForgot = () => {
     if (!currentWord) return;
-
-    const newForgotSlugs = addUnique(forgottenSlugs, currentWord.slug);
-    const newRememberedSlugs = removeValue(rememberedSlugs, currentWord.slug);
-    const newLaterSlugs = removeValue(laterSlugs, currentWord.slug);
-    const newCount = 0;
-
-    setForgottenSlugs(newForgotSlugs);
-    setRememberedSlugs(newRememberedSlugs);
-    setLaterSlugs(newLaterSlugs);
-    setConsecutiveRememberCount(newCount);
-
-    // router.push でアンマウントされる前に同期で永続化（useEffect が走らない可能性があるため）
-    writePersistedState(currentWord.slug, newRememberedSlugs, newForgotSlugs, newLaterSlugs, newCount);
-
+    markForgot(currentWord.slug);
     const query = backLink === '/favorites' ? '?from=review' : '?from=study';
     router.push(`/words/${currentWord.slug}${query}`);
   };
 
   const handleLater = () => {
     if (!currentWord) return;
-
-    const newLaterSlugs = addUnique(laterSlugs, currentWord.slug);
-    const newRememberedSlugs = removeValue(rememberedSlugs, currentWord.slug);
-    const newForgotSlugs = removeValue(forgottenSlugs, currentWord.slug);
-
-    setLaterSlugs(newLaterSlugs);
-    setRememberedSlugs(newRememberedSlugs);
-    setForgottenSlugs(newForgotSlugs);
-    // 「あとで」は判断保留なので連続カウントはリセットしない
-    pickRandomWord();
+    markLater(currentWord.slug);
+    advanceToNextWord();
   };
 
   const handleSelectLaterWord = (word: Word) => {
     setCurrentWord(word);
-    if (typeof window !== 'undefined') {
-      startCountdown();
-      // モバイル（lg未満）ではサイドバーがカードの下に表示されるため、
-      // 選択した単語が反映されたカードを画面内へスクロールする
-      if (window.innerWidth < 1024) {
-        cardRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      }
+    startCardCountdown();
+    // モバイル（lg未満）ではサイドバーがカードの下に表示されるため、
+    // 選択した単語が反映されたカードを画面内へスクロールする
+    if (window.innerWidth < 1024) {
+      cardRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
     }
   };
 
   const handleHint = async () => {
     if (!currentWord) return;
-    
+
     setShowHintButton(false);
     setIsFlipped(true);
     setIsLoadingHint(true);
-    
+
     try {
       const detail = await fetchWordDetail(currentWord.slug);
       if (detail && detail.toeicExamples && detail.toeicExamples.length > 0) {
         setHintExample(detail.toeicExamples[0].english);
       } else {
-        setHintExample("No example available.");
+        setHintExample('No example available.');
       }
     } catch (e) {
       console.error(e);
-      setHintExample("Failed to load example.");
+      setHintExample('Failed to load example.');
     } finally {
       setIsLoadingHint(false);
     }
-  };
-
-  const renderExample = () => {
-    if (!hintExample) return null;
-    
-    const renderContent = () => {
-      if (!currentWord) return <p className="text-xl text-gray-700 text-center leading-[1.6] font-medium max-w-[90%]">{hintExample}</p>;
-
-      const word = currentWord.term;
-      const escapedWord = escapeRegExp(word);
-      const parts = hintExample.split(new RegExp(`(\\b${escapedWord}\\w*)`, 'gi'));
-
-      return (
-        <div className="text-xl text-gray-700 text-center leading-[1.6] font-medium max-w-[90%]">
-          <span className="text-emerald-600 font-extrabold text-[1.1em] mr-2">Sample:</span>
-          {parts.map((part, i) => {
-            const isMatch = new RegExp(`^${escapedWord}\\w*$`, 'i').test(part);
-            return isMatch ? (
-              <span key={i} className="text-gray-900 font-extrabold underline decoration-amber-300 decoration-[3px] bg-amber-200/30 px-[2px] rounded-[2px]">{part}</span>
-            ) : (
-              <span key={i}>{part}</span>
-            );
-          })}
-          <button 
-            className="inline-flex items-center justify-center p-0 border-none bg-transparent cursor-pointer align-middle disabled:opacity-70 disabled:cursor-default ml-2 group" 
-            onClick={() => handlePlaySentenceAudio(hintExample, `hint-example-${currentWord?.slug}`, "en", currentWord?.slug)}
-            disabled={sentenceAudioLoading === `hint-example-${currentWord?.slug}`}
-            aria-label="Play sample audio"
-            style={{ marginLeft: '8px', verticalAlign: 'middle', display: 'inline-flex' }}
-          >
-            <span className="w-[26px] h-[26px] rounded-full inline-flex items-center justify-center bg-gray-100 text-[#5780d8] text-lg leading-none transition-all duration-160 group-hover:translate-y-[-1px] group-hover:shadow-md">
-              {sentenceAudioLoading === `hint-example-${currentWord?.slug}` ? (
-                <Loader2 className="animate-spin" size={14} />
-              ) : (
-                <Volume2 size={14} />
-              )}
-            </span>
-          </button>
-        </div>
-      );
-    };
-
-    return (
-      <div className="flex flex-col items-center gap-1 w-full">
-        {renderContent()}
-      </div>
-    );
   };
 
   if (!currentWord) {
@@ -527,201 +206,56 @@ export default function StudyClient({
             : 'max-w-[600px]'
         }`}
       >
-      <main className="w-full max-w-[600px] flex flex-col gap-8 items-center lg:max-w-none">
-        <header className="flex flex-col gap-3 text-center w-full items-center relative">
-          <Link 
-            href={backLink} 
-            prefetch={false}
-            className="group absolute right-0 -top-4 inline-flex items-center justify-center gap-1.5 h-10 px-5 bg-white border border-gray-200 rounded-full text-slate-600 text-[15px] font-semibold no-underline transition-all duration-200 shadow-sm select-none z-10 hover:bg-gray-50 hover:border-gray-300 hover:text-slate-900 hover:-translate-y-px hover:shadow-md active:translate-y-0 active:shadow-sm"
-          >
-            <ChevronLeft size={18} className="transition-transform group-hover:-translate-x-0.5 text-slate-400 group-hover:text-slate-600" />
-            {backLinkText}
-          </Link>
-          <h1 className="text-[28px] leading-[1.3] text-slate-900 font-bold mt-12 sm:text-[32px]">{pageTitle}</h1>
-          <p className="text-sm leading-[1.6] text-gray-500">
-            表示された単語を知っていますか？
-          </p>
-        </header>
-
-        <section ref={cardRef} className="w-full perspective-[1000px] relative">
-          <div className={`flex flex-col justify-center items-center px-6 py-12 rounded-3xl bg-white/95 border border-gray-200 shadow-[0_10px_25px_rgba(15,23,42,0.08)] transition-all duration-300 min-h-[225px] ${isFlipped ? 'animate-flipIn' : ''}`}>
-            {!isFlipped ? (
-              <div style={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
-                <AutoResizingText text={currentWord.term} className="text-5xl font-bold text-gray-900 text-center mb-3 whitespace-nowrap max-w-full overflow-hidden text-ellipsis" />
-              </div>
-            ) : (
-              <div className="flex flex-col items-center gap-4 w-full animate-flipIn">
-                <div className="flex items-center justify-center gap-3 w-full max-w-full">
-                  <div style={{ minWidth: 0, display: 'flex', justifyContent: 'center' }}>
-                    <AutoResizingText text={currentWord.term} className="text-5xl font-bold text-gray-900 text-center mb-0 whitespace-nowrap max-w-full overflow-hidden text-ellipsis" style={{ marginBottom: 0 }} />
-                  </div>
-                  <button 
-                    className="inline-flex items-center justify-center p-0 border-none bg-transparent cursor-pointer disabled:opacity-70 disabled:cursor-default align-middle group" 
-                    onClick={() => currentWord && handlePlayAudio(currentWord.term)}
-                    disabled={audioLoading}
-                    aria-label="Play word audio"
-                  >
-                    <span className="w-[26px] h-[26px] rounded-full inline-flex items-center justify-center bg-gray-100 text-[#5780d8] text-lg leading-none transition-all duration-160 group-hover:translate-y-[-1px] group-hover:shadow-md">
-                      {audioLoading ? (
-                        <Loader2 className="animate-spin" size={14} />
-                      ) : (
-                        <Volume2 size={14} />
-                      )}
-                    </span>
-                  </button>
-                </div>
-                {isLoadingHint ? (
-                  <div className="flex flex-col items-center gap-1 w-full">
-                    <div className="h-5 w-[80%] mx-auto mb-2 bg-blue-100 rounded relative overflow-hidden after:content-[''] after:absolute after:inset-0 after:-translate-x-full after:animate-shimmer after:bg-gradient-to-r after:from-transparent after:via-white/50 after:to-transparent" />
-                    <div className="h-5 w-[60%] mx-auto mb-2 bg-blue-100 rounded relative overflow-hidden after:content-[''] after:absolute after:inset-0 after:-translate-x-full after:animate-shimmer after:bg-gradient-to-r after:from-transparent after:via-white/50 after:to-transparent" />
-                  </div>
-                ) : (
-                  renderExample()
-                )}
-              </div>
-            )}
-          </div>
-          {countdownValue !== null && (
-            <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-30" aria-hidden="true">
-              <div key={countdownKey} className={`inline-block text-[140px] leading-none font-black drop-shadow-lg animate-countdownCenter ${countdownValue === 2 ? 'text-amber-500/40' : 'text-red-500/40'}`}>
-                {countdownValue}
-              </div>
-            </div>
-          )}
-          {showHintButton && !isFlipped && (
-            <div className="absolute inset-0 flex items-start justify-end p-3.5 pointer-events-none z-20 sm:p-2.5">
-              <button 
-                onClick={handleHint} 
-                className="pointer-events-auto relative flex items-center justify-center px-5 py-2.5 bg-white text-slate-700 border-2 border-amber-300 rounded-full text-sm font-bold cursor-pointer transition-all duration-200 shadow-[0_0_15px_rgba(251,191,36,0.3)] hover:bg-amber-50 hover:-translate-y-1 hover:shadow-[0_0_20px_rgba(251,191,36,0.5)] animate-hintPop overflow-hidden group"
-              >
-                <span className="relative z-10 flex items-center gap-1.5">
-                  <span className="animate-pulse text-base">💡</span> ヒントを見る
-                </span>
-                <div className="absolute inset-0 rounded-full bg-amber-200/30 animate-ping opacity-75"></div>
-              </button>
-            </div>
-          )}
-          {isFlipped && (
-            <div className="absolute inset-0 flex items-start justify-end p-3.5 pointer-events-none z-20 sm:p-2.5">
-              <button
-                onClick={() => currentWord && toggleFavorite(currentWord.slug)}
-                className="pointer-events-auto inline-flex items-center justify-center w-11 h-11 rounded-full border border-gray-200 bg-white text-slate-500 cursor-pointer transition-all duration-200 shadow-sm shrink-0 hover:bg-slate-50 hover:border-slate-300 hover:-translate-y-px hover:shadow-md active:translate-y-0"
-                aria-label={
-                  currentWord && isFavorite(currentWord.slug)
-                    ? 'お気に入りから削除'
-                    : 'お気に入りに追加'
-                }
-              >
-                <Star
-                  size={24}
-                  fill={
-                    currentWord && isFavorite(currentWord.slug)
-                      ? '#FFC107'
-                      : 'none'
-                  }
-                  color={
-                    currentWord && isFavorite(currentWord.slug)
-                      ? '#FFC107'
-                      : '#94a3b8'
-                  }
-                  strokeWidth={2}
-                />
-              </button>
-            </div>
-          )}
-        </section>
-
-        <section className="flex flex-col items-center w-full mt-0">
-          <div className="flex flex-wrap gap-4 w-full justify-center sm:gap-6">
-            <button 
-              className="flex flex-col items-center justify-center gap-2 w-24 h-24 rounded-full border-none cursor-pointer transition-all duration-200 shadow-sm bg-green-200 text-green-900 border-2 border-green-300 hover:bg-green-300 hover:-translate-y-0.5 hover:shadow-md active:translate-y-0 sm:h-[120px] sm:w-[120px]"
-              onClick={handleRemembered}
-              aria-label="覚えている"
+        <main className="w-full max-w-[600px] flex flex-col gap-8 items-center lg:max-w-none">
+          <header className="flex flex-col gap-3 text-center w-full items-center relative">
+            <Link
+              href={backLink}
+              prefetch={false}
+              className="group absolute right-0 -top-4 inline-flex items-center justify-center gap-1.5 h-10 px-5 bg-white border border-gray-200 rounded-full text-slate-600 text-[15px] font-semibold no-underline transition-all duration-200 shadow-sm select-none z-10 hover:bg-gray-50 hover:border-gray-300 hover:text-slate-900 hover:-translate-y-px hover:shadow-md active:translate-y-0 active:shadow-sm"
             >
-              <span className="text-[32px] font-bold">💡</span>
-              <span className="text-[10px] font-semibold leading-none sm:text-sm">覚えている</span>
-            </button>
-            
-            <button 
-              className="flex flex-col items-center justify-center gap-2 w-24 h-24 rounded-full border-none cursor-pointer transition-all duration-200 shadow-sm bg-red-200 text-red-900 border-2 border-red-300 hover:bg-red-300 hover:-translate-y-0.5 hover:shadow-md active:translate-y-0 sm:h-[120px] sm:w-[120px]"
-              onClick={handleForgot}
-              aria-label="覚えていない"
-            >
-              <span className="text-[32px] font-bold">❔</span>
-              <span className="text-[10px] font-semibold leading-none sm:text-sm">覚えていない</span>
-            </button>
+              <ChevronLeft size={18} className="transition-transform group-hover:-translate-x-0.5 text-slate-400 group-hover:text-slate-600" />
+              {backLinkText}
+            </Link>
+            <h1 className="text-[28px] leading-[1.3] text-slate-900 font-bold mt-12 sm:text-[32px]">{pageTitle}</h1>
+            <p className="text-sm leading-[1.6] text-gray-500">
+              表示された単語を知っていますか？
+            </p>
+          </header>
 
-            <button
-              className="flex flex-col items-center justify-center gap-2 w-24 h-24 rounded-full border-none cursor-pointer transition-all duration-200 shadow-sm bg-amber-100 text-amber-900 border-2 border-amber-300 hover:bg-amber-200 hover:-translate-y-0.5 hover:shadow-md active:translate-y-0 sm:h-[120px] sm:w-[120px]"
-              onClick={handleLater}
-              aria-label="あとで確認"
-            >
-              <span className="text-[32px] font-bold">⏰</span>
-              <span className="text-[10px] font-semibold leading-none sm:text-sm">あとで</span>
-            </button>
-          </div>
+          <StudyCard
+            cardRef={cardRef}
+            word={currentWord}
+            isFlipped={isFlipped}
+            isLoadingHint={isLoadingHint}
+            hintExample={hintExample}
+            countdownValue={countdownValue}
+            countdownKey={countdownKey}
+            showHintButton={showHintButton}
+            isFavorite={isFavorite(currentWord.slug)}
+            audioLoading={audioLoading}
+            sentenceAudioLoading={sentenceAudioLoading}
+            onHint={handleHint}
+            onToggleFavorite={() => toggleFavorite(currentWord.slug)}
+            onPlayWordAudio={() => handlePlayAudio(currentWord.term)}
+            onPlaySentenceAudio={handlePlaySentenceAudio}
+          />
 
-          {order !== 'sequential' && (
-            <div className="mt-8 flex items-center gap-2 text-[13px] font-medium text-slate-500 bg-white/50 px-4 py-2 rounded-full border border-slate-200 shadow-sm backdrop-blur-sm transition-all duration-300">
-              <span className="text-amber-500 text-base leading-none">💡</span>
-              <span>連続で「覚えている」を選ぶと難易度が上がります</span>
-              {consecutiveRememberCount > 0 && (
-                <span className="ml-1 px-2 py-0.5 bg-emerald-100 text-emerald-700 rounded-full text-xs font-bold animate-pulse">
-                  {consecutiveRememberCount}連続中 🔥
-                </span>
-              )}
-            </div>
-          )}
-        </section>
-      </main>
+          <StudyActions
+            onRemembered={handleRemembered}
+            onForgot={handleForgot}
+            onLater={handleLater}
+            showDifficultyTip={order !== 'sequential'}
+            consecutiveRememberCount={consecutiveRememberCount}
+          />
+        </main>
 
-      {laterWords.length > 0 && (
-        <aside className="w-full rounded-3xl border border-gray-200 bg-white/90 p-5 shadow-[0_10px_25px_rgba(15,23,42,0.08)] backdrop-blur-sm lg:sticky lg:top-8">
-          <div className="mb-4 flex items-center justify-between gap-3">
-            <div className="flex items-center gap-2">
-              <span className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-amber-100 text-amber-700">
-                <Clock3 size={18} strokeWidth={2.4} />
-              </span>
-              <div>
-                <h2 className="text-base font-bold leading-tight text-slate-900">あとで確認</h2>
-                <p className="text-xs font-medium text-slate-500">{laterWords.length}語を保留中</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="max-h-[420px] space-y-2 overflow-y-auto pr-1">
-            {laterWords.map((word) => {
-              const isActive = currentWord.slug === word.slug;
-
-              return (
-                <button
-                  key={word.slug}
-                  type="button"
-                  onClick={() => handleSelectLaterWord(word)}
-                  className={`group flex w-full items-center justify-between gap-3 rounded-2xl border px-3.5 py-3 text-left transition-all duration-200 ${
-                    isActive
-                      ? 'border-blue-300 bg-blue-50 text-blue-900 shadow-sm'
-                      : 'border-slate-200 bg-white text-slate-700 hover:border-amber-300 hover:bg-amber-50 hover:-translate-y-0.5 hover:shadow-sm'
-                  }`}
-                  aria-current={isActive ? 'true' : undefined}
-                >
-                  <span className="min-w-0">
-                    <span className="block truncate text-sm font-bold">{word.term}</span>
-                    <span className="mt-0.5 block text-xs font-medium text-slate-500">
-                      {word.level === 'important' ? '重要' : word.level === 'medium' ? '中級' : '上級'}
-                    </span>
-                  </span>
-                  <span className={`shrink-0 rounded-full px-2 py-1 text-[11px] font-bold ${
-                    isActive ? 'bg-blue-100 text-blue-700' : 'bg-slate-100 text-slate-500 group-hover:bg-amber-100 group-hover:text-amber-700'
-                  }`}>
-                    確認
-                  </span>
-                </button>
-              );
-            })}
-          </div>
-        </aside>
-      )}
+        {laterWords.length > 0 && (
+          <LaterWordsSidebar
+            words={laterWords}
+            currentSlug={currentWord.slug}
+            onSelect={handleSelectLaterWord}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/hooks/useStudyCountdown.ts
+++ b/src/hooks/useStudyCountdown.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef, useState } from "react";
+import { getNavigationType } from "@/lib/study-utils";
+
+/**
+ * 学習カードの「2→1→0」カウントダウンとヒントボタン表示を管理するフック。
+ * BFCache 復元（戻るボタン）時は、ヒントボタン表示中またはカード裏返し中でなければ
+ * カウントダウンをリセットする。
+ */
+export function useStudyCountdown(isFlipped: boolean) {
+    const [countdownValue, setCountdownValue] = useState<number | null>(null);
+    const [countdownKey, setCountdownKey] = useState(0);
+    const [showHintButton, setShowHintButton] = useState(false);
+    const timeoutsRef = useRef<number[]>([]);
+
+    useEffect(() => {
+        const onPageShow = (event: PageTransitionEvent) => {
+            // 戻るボタンでの遷移時、既にヒントボタンが表示されているか
+            // カードが裏返っている場合は状態をリセットしない
+            //（BFCache で復元された場合でもヒントボタンの状態を維持するため）。
+            if (showHintButton || isFlipped) return;
+            if (event.persisted || getNavigationType() === "back_forward") {
+                for (const id of timeoutsRef.current) {
+                    clearTimeout(id);
+                }
+                timeoutsRef.current = [];
+                setCountdownValue(null);
+                setShowHintButton(false);
+            }
+        };
+
+        window.addEventListener("pageshow", onPageShow);
+        // アンマウント時にカウントダウンをクリアすると、戻るボタンで戻った時に
+        // ヒントボタンが消えてしまうため、リスナー解除のみ行う。
+        return () => window.removeEventListener("pageshow", onPageShow);
+    }, [showHintButton, isFlipped]);
+
+    const startCountdown = () => {
+        for (const id of timeoutsRef.current) {
+            clearTimeout(id);
+        }
+        timeoutsRef.current = [];
+
+        // 2 からカウントダウンし、終了後にヒントボタンを表示する
+        setCountdownValue(2);
+        setShowHintButton(false);
+        setCountdownKey((k) => k + 1);
+
+        const t1 = window.setTimeout(() => {
+            setCountdownValue(1);
+            setCountdownKey((k) => k + 1);
+        }, 1000);
+        const t0 = window.setTimeout(() => {
+            setCountdownValue(0);
+            setCountdownKey((k) => k + 1);
+        }, 2000);
+        const th = window.setTimeout(() => {
+            setCountdownValue(null);
+            setShowHintButton(true);
+        }, 2060); // 2s + 60ms
+
+        timeoutsRef.current = [t1, t0, th];
+    };
+
+    return {
+        countdownValue,
+        countdownKey,
+        showHintButton,
+        setShowHintButton,
+        startCountdown,
+    };
+}

--- a/src/hooks/useStudyProgress.ts
+++ b/src/hooks/useStudyProgress.ts
@@ -1,0 +1,130 @@
+import { useEffect, useState } from "react";
+import {
+    addUnique,
+    removeValue,
+    uniqueStrings,
+    parsePersistedStudyState,
+    type PersistedStudyStateV1,
+} from "@/lib/study-utils";
+
+// モジュールスコープに置くことで useEffect の依存配列に含める必要をなくしている
+function writePersistedState(
+    storageKey: string,
+    slug: string,
+    remembered: string[],
+    forgotten: string[],
+    later: string[],
+    count: number,
+): void {
+    if (typeof window === "undefined") return;
+    try {
+        const nextState: PersistedStudyStateV1 = {
+            v: 1,
+            currentSlug: slug,
+            rememberedSlugs: remembered,
+            forgottenSlugs: forgotten,
+            laterSlugs: later,
+            consecutiveRememberCount: count,
+            updatedAt: Date.now(),
+        };
+        window.sessionStorage.setItem(storageKey, JSON.stringify(nextState));
+    } catch {}
+}
+
+/** sessionStorage から学習状態を読み出す。不正・未保存なら null。 */
+export function readPersistedState(storageKey: string): PersistedStudyStateV1 | null {
+    if (typeof window === "undefined") return null;
+    try {
+        const raw = window.sessionStorage.getItem(storageKey);
+        if (!raw) return null;
+        return parsePersistedStudyState(raw);
+    } catch {
+        return null;
+    }
+}
+
+/** sessionStorage の学習状態を破棄する。 */
+export function clearPersistedState(storageKey: string): void {
+    if (typeof window === "undefined") return;
+    try {
+        window.sessionStorage.removeItem(storageKey);
+    } catch {}
+}
+
+/**
+ * 覚えた / 覚えていない / あとで の学習進捗と連続正解カウントを管理し、
+ * 変更を sessionStorage へ自動永続化するフック。
+ */
+export function useStudyProgress(storageKey: string, currentSlug: string | null) {
+    const [rememberedSlugs, setRememberedSlugs] = useState<string[]>([]);
+    const [forgottenSlugs, setForgottenSlugs] = useState<string[]>([]);
+    const [laterSlugs, setLaterSlugs] = useState<string[]>([]);
+    const [consecutiveRememberCount, setConsecutiveRememberCount] = useState(0);
+
+    useEffect(() => {
+        if (!currentSlug) return;
+        writePersistedState(storageKey, currentSlug, rememberedSlugs, forgottenSlugs, laterSlugs, consecutiveRememberCount);
+    }, [storageKey, currentSlug, rememberedSlugs, forgottenSlugs, laterSlugs, consecutiveRememberCount]);
+
+    /** 「覚えている」: 連続カウントを増やし、増加後のカウントを返す */
+    const markRemembered = (slug: string): number => {
+        setRememberedSlugs((prev) => addUnique(prev, slug));
+        setForgottenSlugs((prev) => removeValue(prev, slug));
+        setLaterSlugs((prev) => removeValue(prev, slug));
+        const newCount = consecutiveRememberCount + 1;
+        setConsecutiveRememberCount(newCount);
+        return newCount;
+    };
+
+    /**
+     * 「覚えていない」: 連続カウントをリセットする。
+     * 直後の router.push でアンマウントされ useEffect が走らない可能性があるため、
+     * ここで同期的に永続化する。
+     */
+    const markForgot = (slug: string): void => {
+        const newForgot = addUnique(forgottenSlugs, slug);
+        const newRemembered = removeValue(rememberedSlugs, slug);
+        const newLater = removeValue(laterSlugs, slug);
+
+        setForgottenSlugs(newForgot);
+        setRememberedSlugs(newRemembered);
+        setLaterSlugs(newLater);
+        setConsecutiveRememberCount(0);
+
+        writePersistedState(storageKey, slug, newRemembered, newForgot, newLater, 0);
+    };
+
+    /** 「あとで」: 判断保留なので連続カウントはリセットしない */
+    const markLater = (slug: string): void => {
+        setLaterSlugs((prev) => addUnique(prev, slug));
+        setRememberedSlugs((prev) => removeValue(prev, slug));
+        setForgottenSlugs((prev) => removeValue(prev, slug));
+    };
+
+    /** sessionStorage から復元した状態を反映する */
+    const restoreProgress = (persisted: PersistedStudyStateV1): void => {
+        setRememberedSlugs(uniqueStrings(persisted.rememberedSlugs));
+        setForgottenSlugs(uniqueStrings(persisted.forgottenSlugs));
+        setLaterSlugs(uniqueStrings(persisted.laterSlugs ?? []));
+        if (persisted.consecutiveRememberCount !== undefined) {
+            setConsecutiveRememberCount(persisted.consecutiveRememberCount);
+        }
+    };
+
+    /** 進捗をすべて破棄する（リロード時） */
+    const resetProgress = (): void => {
+        setRememberedSlugs([]);
+        setForgottenSlugs([]);
+        setLaterSlugs([]);
+    };
+
+    return {
+        laterSlugs,
+        consecutiveRememberCount,
+        markRemembered,
+        markForgot,
+        markLater,
+        restoreProgress,
+        resetProgress,
+    };
+}

--- a/src/lib/(tests)/study-utils.test.ts
+++ b/src/lib/(tests)/study-utils.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect } from "vitest";
+import type { Word } from "@/data/words";
+import {
+  parsePersistedStudyState,
+  uniqueStrings,
+  addUnique,
+  removeValue,
+  escapeRegExp,
+  buildWordMap,
+  splitWordsByLevel,
+  selectWordPool,
+  pickRandomStudyWord,
+  pickSequentialStudyWord,
+  splitSentenceByTerm,
+  getNavigationType,
+  type WordLevelPools,
+} from "../study-utils";
+
+const word = (slug: string, level: Word["level"] = "important"): Word => ({
+  slug,
+  term: slug,
+  level,
+});
+
+/** 固定の乱数列を順に返すスタブ（使い切ったら最後の値を返し続ける） */
+const sequenceRandom = (values: number[]): (() => number) => {
+  let i = 0;
+  return () => values[Math.min(i++, values.length - 1)];
+};
+
+const makePools = (important: Word[], medium: Word[], high: Word[]): WordLevelPools => ({
+  all: [...important, ...medium, ...high],
+  important,
+  medium,
+  high,
+});
+
+describe("parsePersistedStudyState", () => {
+  const valid = {
+    v: 1,
+    currentSlug: "apple",
+    rememberedSlugs: ["banana"],
+    forgottenSlugs: ["cherry"],
+    laterSlugs: ["date"],
+    consecutiveRememberCount: 3,
+    updatedAt: 1700000000000,
+  };
+
+  it("parses a fully populated valid state", () => {
+    expect(parsePersistedStudyState(JSON.stringify(valid))).toEqual(valid);
+  });
+
+  it("accepts a state without the optional fields", () => {
+    const state = {
+      v: 1,
+      currentSlug: "apple",
+      rememberedSlugs: [],
+      forgottenSlugs: [],
+      updatedAt: 1700000000000,
+    };
+    expect(parsePersistedStudyState(JSON.stringify(state))).toEqual(state);
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(parsePersistedStudyState("{not json")).toBeNull();
+  });
+
+  it("returns null for non-object JSON", () => {
+    expect(parsePersistedStudyState("42")).toBeNull();
+    expect(parsePersistedStudyState("null")).toBeNull();
+  });
+
+  it("returns null for an unknown version", () => {
+    expect(parsePersistedStudyState(JSON.stringify({ ...valid, v: 2 }))).toBeNull();
+  });
+
+  it("returns null when currentSlug is not a string", () => {
+    expect(parsePersistedStudyState(JSON.stringify({ ...valid, currentSlug: 1 }))).toBeNull();
+  });
+
+  it("returns null when a slug array contains a non-string", () => {
+    expect(parsePersistedStudyState(JSON.stringify({ ...valid, rememberedSlugs: ["a", 1] }))).toBeNull();
+    expect(parsePersistedStudyState(JSON.stringify({ ...valid, forgottenSlugs: "a" }))).toBeNull();
+    expect(parsePersistedStudyState(JSON.stringify({ ...valid, laterSlugs: [null] }))).toBeNull();
+  });
+
+  it("returns null when consecutiveRememberCount is not a number", () => {
+    expect(parsePersistedStudyState(JSON.stringify({ ...valid, consecutiveRememberCount: "3" }))).toBeNull();
+  });
+
+  it("returns null when updatedAt is missing", () => {
+    const rest: Record<string, unknown> = { ...valid };
+    delete rest.updatedAt;
+    expect(parsePersistedStudyState(JSON.stringify(rest))).toBeNull();
+  });
+});
+
+describe("array helpers", () => {
+  it("uniqueStrings deduplicates while preserving order", () => {
+    expect(uniqueStrings(["a", "b", "a", "c", "b"])).toEqual(["a", "b", "c"]);
+  });
+
+  it("addUnique appends a new value", () => {
+    expect(addUnique(["a"], "b")).toEqual(["a", "b"]);
+  });
+
+  it("addUnique returns the same array when the value already exists", () => {
+    const values = ["a", "b"];
+    expect(addUnique(values, "a")).toBe(values);
+  });
+
+  it("removeValue removes all occurrences", () => {
+    expect(removeValue(["a", "b", "a"], "a")).toEqual(["b"]);
+  });
+});
+
+describe("escapeRegExp", () => {
+  it("escapes regex metacharacters so they match literally", () => {
+    const pattern = new RegExp(`^${escapeRegExp("a.b+(c)")}$`);
+    expect(pattern.test("a.b+(c)")).toBe(true);
+    expect(pattern.test("aXb+(c)")).toBe(false);
+  });
+});
+
+describe("buildWordMap", () => {
+  it("indexes words by slug", () => {
+    const a = word("apple");
+    const b = word("banana");
+    const map = buildWordMap([a, b]);
+    expect(map.get("apple")).toBe(a);
+    expect(map.get("banana")).toBe(b);
+    expect(map.size).toBe(2);
+  });
+});
+
+describe("splitWordsByLevel", () => {
+  it("partitions words into level pools and keeps the full list", () => {
+    const words = [word("a", "important"), word("b", "medium"), word("c", "high"), word("d", "medium")];
+    const pools = splitWordsByLevel(words);
+    expect(pools.all).toEqual(words);
+    expect(pools.important.map((w) => w.slug)).toEqual(["a"]);
+    expect(pools.medium.map((w) => w.slug)).toEqual(["b", "d"]);
+    expect(pools.high.map((w) => w.slug)).toEqual(["c"]);
+  });
+});
+
+describe("selectWordPool", () => {
+  const important = [word("imp", "important")];
+  const medium = [word("med", "medium")];
+  const high = [word("hig", "high")];
+  const pools = makePools(important, medium, high);
+
+  it("tier 0-4: picks important at r < 0.8, medium otherwise", () => {
+    expect(selectWordPool(0, 0.79, pools)).toBe(important);
+    expect(selectWordPool(4, 0.8, pools)).toBe(medium);
+  });
+
+  it("tier 0-4: falls back to medium then high when pools are empty", () => {
+    expect(selectWordPool(0, 0.1, makePools([], medium, high))).toBe(medium);
+    expect(selectWordPool(0, 0.1, makePools([], [], high))).toBe(high);
+  });
+
+  it("tier 5-9: picks medium at r < 0.6, important at r < 0.8, high otherwise", () => {
+    expect(selectWordPool(5, 0.59, pools)).toBe(medium);
+    expect(selectWordPool(7, 0.79, pools)).toBe(important);
+    expect(selectWordPool(9, 0.8, pools)).toBe(high);
+  });
+
+  it("tier 5-9: falls back to medium when high is empty", () => {
+    expect(selectWordPool(5, 0.9, makePools(important, medium, []))).toBe(medium);
+  });
+
+  it("tier 10+: picks high at r < 0.6, medium at r < 0.9, important otherwise", () => {
+    expect(selectWordPool(10, 0.59, pools)).toBe(high);
+    expect(selectWordPool(15, 0.89, pools)).toBe(medium);
+    expect(selectWordPool(10, 0.9, pools)).toBe(important);
+  });
+
+  it("tier 10+: falls back to high when important is empty", () => {
+    expect(selectWordPool(10, 0.95, makePools([], medium, high))).toBe(high);
+    expect(selectWordPool(10, 0.95, makePools([], [], high))).toBe(high);
+  });
+
+  it("returns the full list when every level pool is empty", () => {
+    const all = [word("x")];
+    expect(selectWordPool(0, 0.1, { all, important: [], medium: [], high: [] })).toBe(all);
+  });
+});
+
+describe("pickRandomStudyWord", () => {
+  it("returns null for an empty word list", () => {
+    expect(pickRandomStudyWord(makePools([], [], []), null, 0)).toBeNull();
+  });
+
+  it("returns the only word even when it matches the current slug", () => {
+    const only = word("solo");
+    const result = pickRandomStudyWord(makePools([only], [], []), "solo", 0, sequenceRandom([0]));
+    expect(result).toBe(only);
+  });
+
+  it("re-draws when the picked word matches the current slug", () => {
+    const a = word("a");
+    const b = word("b");
+    // 1回目: r=0.1 → important プール, index 0 → a（現在の単語と同じ）
+    // 2回目: r=0.1 → important プール, index 0.9*2=1 → b
+    const result = pickRandomStudyWord(makePools([a, b], [], []), "a", 0, sequenceRandom([0.1, 0, 0.1, 0.9]));
+    expect(result).toBe(b);
+  });
+
+  it("gives up after 10 attempts and returns the duplicate", () => {
+    const a = word("a");
+    const b = word("b");
+    let calls = 0;
+    const alwaysFirst = () => {
+      calls++;
+      return 0;
+    };
+    const result = pickRandomStudyWord(makePools([a, b], [], []), "a", 0, alwaysFirst);
+    expect(result).toBe(a);
+    expect(calls).toBe(20); // 10 試行 × 2 回
+  });
+
+  it("respects the difficulty tier of the consecutive count", () => {
+    const imp = word("imp", "important");
+    const hig = word("hig", "high");
+    const pools = makePools([imp], [], [hig]);
+    expect(pickRandomStudyWord(pools, null, 10, sequenceRandom([0.5, 0]))).toBe(hig);
+    expect(pickRandomStudyWord(pools, null, 0, sequenceRandom([0.5, 0]))).toBe(imp);
+  });
+});
+
+describe("pickSequentialStudyWord", () => {
+  const words = [word("a"), word("b"), word("c")];
+
+  it("returns null for an empty list", () => {
+    expect(pickSequentialStudyWord([], null)).toBeNull();
+  });
+
+  it("returns the first word when there is no current word", () => {
+    expect(pickSequentialStudyWord(words, null)).toBe(words[0]);
+  });
+
+  it("returns the next word", () => {
+    expect(pickSequentialStudyWord(words, "a")).toBe(words[1]);
+  });
+
+  it("wraps around from the last word to the first", () => {
+    expect(pickSequentialStudyWord(words, "c")).toBe(words[0]);
+  });
+
+  it("returns the first word when the current slug is unknown", () => {
+    expect(pickSequentialStudyWord(words, "zzz")).toBe(words[0]);
+  });
+});
+
+describe("splitSentenceByTerm", () => {
+  const matched = (parts: ReturnType<typeof splitSentenceByTerm>) =>
+    parts.filter((p) => p.isMatch).map((p) => p.text);
+
+  it("highlights the exact term", () => {
+    const parts = splitSentenceByTerm("I respect you.", "respect");
+    expect(matched(parts)).toEqual(["respect"]);
+    expect(parts.map((p) => p.text).join("")).toBe("I respect you.");
+  });
+
+  it("highlights inflected forms (suffixes)", () => {
+    expect(matched(splitSentenceByTerm("She respects him.", "respect"))).toEqual(["respects"]);
+  });
+
+  it("is case-insensitive", () => {
+    expect(matched(splitSentenceByTerm("Respect is earned.", "respect"))).toEqual(["Respect"]);
+  });
+
+  it("does not match inside another word (word boundary)", () => {
+    expect(matched(splitSentenceByTerm("This is important.", "port"))).toEqual([]);
+  });
+
+  it("handles terms containing regex metacharacters", () => {
+    expect(matched(splitSentenceByTerm("Please check-in early.", "check-in"))).toEqual(["check-in"]);
+  });
+
+  it("highlights multiple occurrences", () => {
+    expect(matched(splitSentenceByTerm("respect begets respect", "respect"))).toEqual(["respect", "respect"]);
+  });
+});
+
+describe("getNavigationType", () => {
+  it("returns undefined outside the browser", () => {
+    expect(getNavigationType()).toBeUndefined();
+  });
+});

--- a/src/lib/study-utils.ts
+++ b/src/lib/study-utils.ts
@@ -1,0 +1,187 @@
+import type { Word } from "@/data/words";
+
+/** sessionStorage に保存する学習状態（バージョン 1） */
+export type PersistedStudyStateV1 = {
+  v: 1;
+  currentSlug: string;
+  rememberedSlugs: string[];
+  forgottenSlugs: string[];
+  laterSlugs?: string[];
+  consecutiveRememberCount?: number;
+  updatedAt: number;
+};
+
+/** レベル別に分割した出題プール */
+export type WordLevelPools = {
+  all: Word[];
+  important: Word[];
+  medium: Word[];
+  high: Word[];
+};
+
+/** 例文をハイライト対象/非対象に分割した断片 */
+export type SentencePart = {
+  text: string;
+  isMatch: boolean;
+};
+
+/**
+ * sessionStorage の生文字列を検証付きでパースする。
+ * 形式が不正な場合は null を返す（例外は投げない）。
+ */
+export function parsePersistedStudyState(raw: string): PersistedStudyStateV1 | null {
+  try {
+    const data = JSON.parse(raw) as unknown;
+    if (!data || typeof data !== "object") return null;
+    const obj = data as Record<string, unknown>;
+    if (obj.v !== 1) return null;
+    if (typeof obj.currentSlug !== "string") return null;
+    if (!Array.isArray(obj.rememberedSlugs) || !obj.rememberedSlugs.every((s) => typeof s === "string")) {
+      return null;
+    }
+    if (!Array.isArray(obj.forgottenSlugs) || !obj.forgottenSlugs.every((s) => typeof s === "string")) {
+      return null;
+    }
+    if (obj.laterSlugs !== undefined && (!Array.isArray(obj.laterSlugs) || !obj.laterSlugs.every((s) => typeof s === "string"))) {
+      return null;
+    }
+    if (obj.consecutiveRememberCount !== undefined && typeof obj.consecutiveRememberCount !== "number") return null;
+    if (typeof obj.updatedAt !== "number") return null;
+    return obj as PersistedStudyStateV1;
+  } catch {
+    return null;
+  }
+}
+
+export function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+export function addUnique(values: string[], value: string): string[] {
+  if (values.includes(value)) return values;
+  return [...values, value];
+}
+
+export function removeValue(values: string[], value: string): string[] {
+  return values.filter((v) => v !== value);
+}
+
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** slug → Word の索引を作る */
+export function buildWordMap(words: Word[]): Map<string, Word> {
+  const map = new Map<string, Word>();
+  for (const w of words) {
+    map.set(w.slug, w);
+  }
+  return map;
+}
+
+/** 単語リストをレベル別の出題プールに分割する */
+export function splitWordsByLevel(words: Word[]): WordLevelPools {
+  return {
+    all: words,
+    important: words.filter((w) => w.level === "important"),
+    medium: words.filter((w) => w.level === "medium"),
+    high: words.filter((w) => w.level === "high"),
+  };
+}
+
+/**
+ * 連続正解回数による段階的な難易度調整で出題プールを選ぶ。
+ * - 0〜4回: important 中心 (important 80%, medium 20%)
+ * - 5〜9回: medium 中心 (important 20%, medium 60%, high 20%)
+ * - 10回〜: high 中心 (important 10%, medium 30%, high 60%)
+ * 該当レベルに単語が無い場合は存在するプールへフォールバックする。
+ *
+ * @param r 0 以上 1 未満の乱数（テストでは固定値を渡して分岐を検証できる）
+ */
+export function selectWordPool(consecutiveRememberCount: number, r: number, pools: WordLevelPools): Word[] {
+  const { all, important, medium, high } = pools;
+
+  if (consecutiveRememberCount < 5) {
+    if (r < 0.8 && important.length > 0) return important;
+    if (medium.length > 0) return medium;
+    if (high.length > 0) return high;
+  } else if (consecutiveRememberCount < 10) {
+    if (r < 0.6 && medium.length > 0) return medium;
+    if (r < 0.8 && important.length > 0) return important;
+    if (high.length > 0) return high;
+    if (medium.length > 0) return medium;
+  } else {
+    if (r < 0.6 && high.length > 0) return high;
+    if (r < 0.9 && medium.length > 0) return medium;
+    if (important.length > 0) return important;
+    if (high.length > 0) return high;
+  }
+
+  return all;
+}
+
+/**
+ * ランダム出題: 難易度調整済みプールから次の単語を選ぶ。
+ * 現在の単語と同じものは最大 10 回まで再抽選する（単語が 2 語以上ある場合のみ）。
+ * random は 1 試行につき 2 回呼ばれる（プール選択用・インデックス用）。
+ */
+export function pickRandomStudyWord(
+  pools: WordLevelPools,
+  currentSlug: string | null,
+  consecutiveRememberCount: number,
+  random: () => number = Math.random,
+): Word | null {
+  if (pools.all.length === 0) return null;
+
+  let nextWord: Word;
+  let safetyCounter = 0;
+
+  do {
+    const pool = selectWordPool(consecutiveRememberCount, random(), pools);
+    nextWord = pool[Math.floor(random() * pool.length)];
+    safetyCounter++;
+  } while (
+    pools.all.length > 1 &&
+    currentSlug !== null &&
+    nextWord.slug === currentSlug &&
+    safetyCounter < 10
+  );
+
+  return nextWord;
+}
+
+/**
+ * 順番出題: 現在の単語の次を返す（末尾の次は先頭へ戻る）。
+ * currentSlug が null またはリストに無い場合は先頭を返す。
+ */
+export function pickSequentialStudyWord(words: Word[], currentSlug: string | null): Word | null {
+  if (words.length === 0) return null;
+  if (currentSlug === null) return words[0];
+  const currentIndex = words.findIndex((w) => w.slug === currentSlug);
+  return words[(currentIndex + 1) % words.length];
+}
+
+/**
+ * 例文を対象単語（語頭一致 + 活用形 \w*）で分割し、各断片にハイライト対象かどうかを付与する。
+ * 大文字小文字は区別しない。
+ */
+export function splitSentenceByTerm(sentence: string, term: string): SentencePart[] {
+  const escaped = escapeRegExp(term);
+  const parts = sentence.split(new RegExp(`(\\b${escaped}\\w*)`, "gi"));
+  const matcher = new RegExp(`^${escaped}\\w*$`, "i");
+  return parts.map((text) => ({ text, isMatch: matcher.test(text) }));
+}
+
+/**
+ * Navigation Timing API から遷移種別（"reload" / "back_forward" など）を取得する。
+ * ブラウザ以外の環境では undefined を返す。
+ */
+export function getNavigationType(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  const entry = window.performance.getEntriesByType("navigation")[0];
+  if (!entry) return undefined;
+  if ("type" in entry) {
+    return (entry as PerformanceNavigationTiming).type;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## 概要

`StudyClient.tsx`(728 行)は SonarCloud で認知的複雑度 41 が指摘され、ESLint の `react-hooks/exhaustive-deps` 警告 5 件も集中していました。挙動を変えずにリファクタリングし、262 行のオーケストレーターに縮小しました。

## 変更内容

### ① 純粋ロジック抽出(`src/lib/study-utils.ts` + 40 テスト)
- 連続正解数による難易度プール選択 `selectWordPool`(0〜4回: important 中心 / 5〜9回: medium 中心 / 10回〜: high 中心、フォールバック含む)
- 同一単語の再抽選付きランダム出題 `pickRandomStudyWord`(乱数を注入式にして全分岐を決定的にテスト)
- 順番出題 `pickSequentialStudyWord`、`sessionStorage` 保存状態のパース `parsePersistedStudyState`、例文ハイライト分割 `splitSentenceByTerm` など
- `src/lib/(tests)/study-utils.test.ts` に 40 件のユニットテストを追加

### ② コンポーネント / フック分割
- **コンポーネント**: `StudyCard`(カード + カウントダウン / ヒント / お気に入りオーバーレイ)、`StudyActions`、`LaterWordsSidebar`、`HintExample`、`AutoResizingText`
- **フック**: `useStudyCountdown`(カウントダウン + BFCache 復元判定)、`useStudyProgress`(学習進捗 + `sessionStorage` 永続化)
- ESLint 警告 5 件は、関数を effect 内またはモジュールスコープへ移す構造で解消(React Compiler 方針に従い手動 `useCallback` は不使用)

### ドキュメント
- README / 技術ドキュメント(v4.8、最終更新日 2026-07-19)/ CLAUDE.md のテストスイート一覧を更新(一覧から漏れていた `favorites-sync` / `safe-compare` も追記)

## 検証

- [x] `npm run lint` — 警告 0 件(従来 5 件 → 0 件)
- [x] `npm run test` — 108 件パス(うち新規 40 件)
- [x] `npm run build` — 成功
- [x] 手動スモークテスト(`/study` と `/review`: 出題 → 3 ボタン、ヒント表示、戻るボタン、リロード)

## 補足

- 挙動変更はありません(出題ロジック・カウントダウン・BFCache / sessionStorage 復元とも元コードを忠実に移植)
- 認知的複雑度は各関数 15 前後以下に収まる見込みです。正確な数値は SonarCloud の次回スキャンで確認してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)